### PR TITLE
Add desert night dark mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+      - run: npx astro check
+      - run: npm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   workflow_dispatch:
 
 permissions:
@@ -21,8 +21,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
-      - run: npm install
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npx astro check
       - run: npm run build
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/docs/plans/2026-03-09-desert-night-dark-mode-design.md
+++ b/docs/plans/2026-03-09-desert-night-dark-mode-design.md
@@ -1,0 +1,74 @@
+# Desert Night Dark Mode
+
+## Overview
+
+A dark mode for walk·talk·meditate that transforms the site into a desert night experience. The warm sand palette inverts to dark earth tones, firefly particles become a layered starry sky, and a campfire/stars toggle gives users control.
+
+## Color System
+
+CSS custom properties on `:root` and `[data-theme="dark"]`. The sand scale reverses and shifts warmer/darker.
+
+| Role | Light | Dark |
+|------|-------|------|
+| Background | sand-50 #FAFAF7 | dusk-950 ~#141311 |
+| Surface | sand-100 #F5F5F0 | dusk-900 ~#1C1A17 |
+| Border | sand-200 #E8E6DF | dusk-800 ~#2B2926 |
+| Muted | sand-300 #D4D1C7 | dusk-700 ~#3D3A35 |
+| Secondary text | sand-500 #918C7E | dusk-400 ~#8A8578 |
+| Body text | sand-700 #4A4740 | dusk-200 ~#D4D1C7 |
+| Headings | sand-800 #2D2B28 | dusk-100 ~#EEECE7 |
+| Accent | sage #7C9070 | sage-light #8FA382 |
+
+## Particle System
+
+### Light Mode (unchanged)
+
+Fireflies (wandering glowing dots) and expanding ripples. No changes from current behavior.
+
+### Dark Mode: Layered Night Sky
+
+**Fixed twinkling stars:**
+- 30-40 small dots (1-3px), randomly positioned, fixed in place
+- Opacity pulse 0.3 → 1.0 → 0.3 at varying speeds (2-6s cycles)
+- Mix of warm white (#EEECE7) and faint amber (#D4C5A0)
+
+**Shooting stars:**
+- Thin streak with soft glow tail
+- Slow diagonal arc across partial viewport
+- One every 15-30s (rare, special)
+- Amber-white, fades out at end of arc
+
+**Ripples:**
+- Shift to softer moonlit silver tone
+- Slightly more transparent than light mode
+
+## Toggle Component
+
+**Placement:** Header, right side near nav links.
+
+**Icons:**
+- Light mode active: campfire SVG (flame shapes above crossed logs)
+- Dark mode active: star cluster SVG (3-4 small stars)
+
+**Behavior:**
+- Fade/scale transition (~200ms) on click
+- Persists in localStorage
+- First visit defaults to `prefers-color-scheme`
+- No flash of wrong theme (inline script in `<head>` before render)
+
+## Technical Approach
+
+- `<html data-theme="dark">` attribute for theme state
+- Tailwind `darkMode: ['selector', '[data-theme="dark"]']`
+- CSS custom properties for all color tokens
+- Inline `<script>` in BaseLayout `<head>` for flash prevention
+- Particles.astro branches: light → fireflies, dark → stars + shooting stars
+- ThemeToggle component in Header
+
+## What Stays the Same
+
+- Typography (fonts, sizes, spacing)
+- Layout and structure
+- All content and navigation patterns
+- Breathing dots (color shifts to light sand)
+- Reading progress bar (shifts to sage-dark)

--- a/docs/plans/2026-03-09-desert-night-implementation.md
+++ b/docs/plans/2026-03-09-desert-night-implementation.md
@@ -1,0 +1,740 @@
+# Desert Night Dark Mode — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a "desert night" dark mode with inverted warm palette, layered starry sky particles, and a campfire/stars theme toggle.
+
+**Architecture:** CSS custom properties on `:root` / `[data-theme="dark"]` drive all colors. Tailwind's `darkMode: ['selector', '[data-theme="dark"]']` enables `dark:` utilities. An inline `<head>` script prevents flash. Particles.astro branches behavior based on theme.
+
+**Tech Stack:** Astro 5, Tailwind CSS 3, vanilla JS (no new dependencies)
+
+---
+
+### Task 1: Tailwind Config — Enable Dark Mode Selector
+
+**Files:**
+- Modify: `tailwind.config.mjs`
+
+**Step 1: Add darkMode and dusk palette**
+
+```js
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
+  darkMode: ['selector', '[data-theme="dark"]'],
+  theme: {
+    extend: {
+      colors: {
+        sand: {
+          50: '#FAFAF7',
+          100: '#F5F5F0',
+          200: '#E8E6DF',
+          300: '#D4D1C7',
+          400: '#B5B1A4',
+          500: '#918C7E',
+          600: '#6E6A5E',
+          700: '#4A4740',
+          800: '#2D2B28',
+          900: '#1A1917',
+        },
+        dusk: {
+          100: '#EEECE7',
+          200: '#D4D1C7',
+          300: '#B5B1A4',
+          400: '#8A8578',
+          500: '#6E6A5E',
+          600: '#4A4740',
+          700: '#3D3A35',
+          800: '#2B2926',
+          900: '#1C1A17',
+          950: '#141311',
+        },
+        sage: {
+          DEFAULT: '#7C9070',
+          light: '#8FA382',
+        },
+      },
+      fontFamily: {
+        heading: ['"Cormorant Garamond"', 'Georgia', 'serif'],
+        body: ['"Source Serif 4"', 'Georgia', 'serif'],
+        ui: ['Inter', 'system-ui', 'sans-serif'],
+      },
+      maxWidth: {
+        prose: '38rem',
+        wide: '48rem',
+      },
+      letterSpacing: {
+        display: '-0.02em',
+      },
+    },
+  },
+  plugins: [],
+};
+```
+
+Note: `sage` changes from a plain string to an object with `DEFAULT` and `light`. All existing `text-sage`, `bg-sage` references continue to work because of `DEFAULT`.
+
+**Step 2: Verify build succeeds**
+
+Run: `npm run build`
+Expected: Build completes with no errors.
+
+**Step 3: Commit**
+
+```bash
+git add tailwind.config.mjs
+git commit -m "feat: add dark mode selector and dusk palette to Tailwind config"
+```
+
+---
+
+### Task 2: Global CSS — Dark Mode Base Styles and Particle Keyframes
+
+**Files:**
+- Modify: `src/styles/global.css`
+
+**Step 1: Add dark base styles and star/shooting-star keyframes**
+
+After the existing `@layer base` block (line 19), and within the existing animation sections, apply these changes:
+
+1. Update the `@layer base` block to include dark overrides:
+
+```css
+@layer base {
+  html {
+    @apply bg-sand-50 text-sand-800;
+    scroll-behavior: smooth;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  [data-theme="dark"] {
+    @apply bg-dusk-950 text-dusk-200;
+  }
+
+  body {
+    @apply font-body text-lg leading-relaxed;
+  }
+
+  ::selection {
+    @apply bg-sage/20;
+  }
+
+  [data-theme="dark"] ::selection {
+    @apply bg-sage-light/20;
+  }
+}
+```
+
+2. Add dark-mode variants for existing particle styles. After the `.firefly` block (after line 50), add:
+
+```css
+[data-theme="dark"] .firefly {
+  display: none;
+}
+```
+
+3. After the `.ripple` block (after line 79), add dark ripple override:
+
+```css
+[data-theme="dark"] .ripple {
+  border-color: rgba(212, 209, 199, 0.15);
+}
+```
+
+4. After the breathing-dot styles (after line 122), add dark override:
+
+```css
+[data-theme="dark"] .breathing-dot {
+  background: theme('colors.dusk.400');
+}
+```
+
+5. Add new star keyframes after the ripple-expand keyframes (after line 79, before scroll reveal):
+
+```css
+/* ---- Stars (dark mode) ---- */
+
+.star {
+  position: absolute;
+  border-radius: 50%;
+  background: #EEECE7;
+  animation: twinkle ease-in-out infinite;
+}
+
+.star--amber {
+  background: #D4C5A0;
+}
+
+@keyframes twinkle {
+  0%, 100% {
+    opacity: 0.3;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+/* ---- Shooting stars (dark mode) ---- */
+
+.shooting-star {
+  position: absolute;
+  width: 2px;
+  height: 2px;
+  background: #EEECE7;
+  border-radius: 50%;
+  box-shadow: 0 0 4px 1px rgba(212, 197, 160, 0.6);
+  animation: shoot linear forwards;
+  opacity: 0;
+}
+
+@keyframes shoot {
+  0% {
+    opacity: 0;
+    transform: translate(0, 0);
+  }
+  5% {
+    opacity: 1;
+  }
+  70% {
+    opacity: 0.6;
+  }
+  100% {
+    opacity: 0;
+    transform: translate(var(--shoot-x), var(--shoot-y));
+  }
+}
+```
+
+6. Update prose-content dark mode overrides. After the existing `.prose-content` styles (after line 239), add:
+
+```css
+/* ---- Prose dark mode ---- */
+
+[data-theme="dark"] .prose-content p {
+  @apply text-dusk-200;
+}
+
+[data-theme="dark"] .prose-content h2,
+[data-theme="dark"] .prose-content h3,
+[data-theme="dark"] .prose-content h4 {
+  @apply text-dusk-100;
+}
+
+[data-theme="dark"] .prose-content ul,
+[data-theme="dark"] .prose-content ol {
+  @apply text-dusk-200;
+}
+
+[data-theme="dark"] .prose-content ul > li::marker {
+  @apply text-dusk-700;
+}
+
+[data-theme="dark"] .prose-content ol > li::marker {
+  @apply text-dusk-400;
+}
+
+[data-theme="dark"] .prose-content blockquote {
+  @apply text-dusk-400 border-dusk-700;
+}
+
+[data-theme="dark"] .prose-content blockquote p {
+  @apply text-dusk-400;
+}
+
+[data-theme="dark"] .prose-content a {
+  @apply text-dusk-100 decoration-dusk-700 hover:decoration-sage-light;
+}
+
+[data-theme="dark"] .prose-content strong {
+  @apply text-dusk-100;
+}
+
+[data-theme="dark"] .prose-content hr {
+  @apply border-dusk-800;
+}
+
+[data-theme="dark"] .prose-content thead {
+  @apply border-dusk-800;
+}
+
+[data-theme="dark"] .prose-content th {
+  @apply text-dusk-400;
+}
+
+[data-theme="dark"] .prose-content td {
+  @apply text-dusk-200 border-dusk-900;
+}
+```
+
+**Step 2: Verify build succeeds**
+
+Run: `npm run build`
+Expected: Build completes with no errors.
+
+**Step 3: Commit**
+
+```bash
+git add src/styles/global.css
+git commit -m "feat: add dark mode base styles, star keyframes, and prose overrides"
+```
+
+---
+
+### Task 3: Flash Prevention Script + Theme Data Attribute in BaseLayout
+
+**Files:**
+- Modify: `src/layouts/BaseLayout.astro`
+
+**Step 1: Add inline theme-init script in `<head>` and data-theme to `<html>`**
+
+The `<html>` tag on line 16 changes to:
+
+```html
+<html lang="en" data-theme="">
+```
+
+Add this inline script immediately after the `<title>` tag (line 44), before `</head>`:
+
+```html
+<script is:inline>
+  (function() {
+    var stored = localStorage.getItem('theme');
+    var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    var theme = stored || (prefersDark ? 'dark' : 'light');
+    document.documentElement.setAttribute('data-theme', theme);
+  })();
+</script>
+```
+
+`is:inline` is critical — it tells Astro not to bundle/defer this script, so it runs before paint.
+
+**Step 2: Verify build succeeds**
+
+Run: `npm run build`
+Expected: Build completes. The `<html>` tag in output has `data-theme=""` and the inline script appears in `<head>`.
+
+**Step 3: Commit**
+
+```bash
+git add src/layouts/BaseLayout.astro
+git commit -m "feat: add theme flash prevention script in head"
+```
+
+---
+
+### Task 4: ThemeToggle Component
+
+**Files:**
+- Create: `src/components/ThemeToggle.astro`
+
+**Step 1: Create the ThemeToggle component**
+
+```astro
+---
+---
+
+<button
+  id="theme-toggle"
+  class="p-2 text-sand-400 hover:text-sand-600 dark:text-dusk-400 dark:hover:text-dusk-200 transition-colors"
+  aria-label="Toggle theme"
+>
+  <svg id="icon-campfire" class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M12 3c-1 4-4 6-4 10a4 4 0 0 0 8 0c0-4-3-6-4-10z" />
+    <path d="M8 21h8" />
+    <path d="M6 21l2-4" />
+    <path d="M18 21l-2-4" />
+  </svg>
+  <svg id="icon-stars" class="w-5 h-5 hidden" viewBox="0 0 24 24" fill="currentColor" stroke="none">
+    <circle cx="6" cy="6" r="1.5" />
+    <circle cx="18" cy="4" r="1" />
+    <circle cx="14" cy="10" r="1.5" />
+    <circle cx="4" cy="14" r="1" />
+    <circle cx="20" cy="16" r="1.5" />
+    <circle cx="10" cy="18" r="1" />
+  </svg>
+</button>
+
+<script>
+  function initThemeToggle() {
+    const btn = document.getElementById('theme-toggle');
+    const iconCampfire = document.getElementById('icon-campfire');
+    const iconStars = document.getElementById('icon-stars');
+    if (!btn || !iconCampfire || !iconStars) return;
+
+    function updateIcons() {
+      var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+      iconCampfire.classList.toggle('hidden', isDark);
+      iconStars.classList.toggle('hidden', !isDark);
+    }
+
+    updateIcons();
+
+    btn.addEventListener('click', function() {
+      var current = document.documentElement.getAttribute('data-theme');
+      var next = current === 'dark' ? 'light' : 'dark';
+      document.documentElement.setAttribute('data-theme', next);
+      localStorage.setItem('theme', next);
+      updateIcons();
+      window.dispatchEvent(new CustomEvent('theme-changed', { detail: { theme: next } }));
+    });
+  }
+
+  initThemeToggle();
+  document.addEventListener('astro:after-swap', initThemeToggle);
+</script>
+
+<style>
+  #theme-toggle {
+    transition: transform 0.2s ease, opacity 0.2s ease;
+  }
+  #theme-toggle:active {
+    transform: scale(0.9);
+  }
+</style>
+```
+
+The toggle dispatches a `theme-changed` custom event so Particles.astro can react.
+
+**Step 2: Verify build succeeds**
+
+Run: `npm run build`
+Expected: Build completes with no errors.
+
+**Step 3: Commit**
+
+```bash
+git add src/components/ThemeToggle.astro
+git commit -m "feat: add ThemeToggle component with campfire/stars icons"
+```
+
+---
+
+### Task 5: Add ThemeToggle to Header
+
+**Files:**
+- Modify: `src/components/Header.astro`
+
+**Step 1: Import and place ThemeToggle**
+
+Add import at top of frontmatter (after line 1):
+
+```astro
+import ThemeToggle from './ThemeToggle.astro';
+```
+
+In the desktop nav `<ul>` (line 34), add the toggle after the last `{navItems.map(...)}`:
+
+```html
+<ul class="hidden md:flex items-center gap-8 font-ui text-[13px] tracking-wide">
+  {navItems.map(item => (
+    <li>
+      <a href={item.href} class="nav-link text-sand-400 hover:text-sand-700 dark:text-dusk-400 dark:hover:text-dusk-200 transition-colors">
+        {item.label}
+      </a>
+    </li>
+  ))}
+  <li><ThemeToggle /></li>
+</ul>
+```
+
+For mobile, add ThemeToggle before the hamburger button. Place it in a flex container with the hamburger (line 23-32):
+
+```html
+<div class="flex items-center gap-2 md:hidden">
+  <ThemeToggle />
+  <button
+    id="menu-toggle"
+    class="p-2 text-sand-400 hover:text-sand-600 dark:text-dusk-400 dark:hover:text-dusk-200"
+    aria-label="Toggle menu"
+    aria-expanded="false"
+  >
+    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1" d="M4 6h16M4 12h16M4 18h16" />
+    </svg>
+  </button>
+</div>
+```
+
+**Step 2: Add dark: classes to all Header color references**
+
+Update these existing classes throughout the file:
+- `text-sand-800` → add `dark:text-dusk-100`
+- `text-sand-400` → add `dark:text-dusk-400`
+- `text-sand-700` → add `dark:text-dusk-200`
+- `text-sand-600` → add `dark:text-dusk-300`
+
+**Step 3: Verify build succeeds**
+
+Run: `npm run build`
+Expected: Build completes with no errors.
+
+**Step 4: Commit**
+
+```bash
+git add src/components/Header.astro
+git commit -m "feat: add theme toggle to header with dark mode colors"
+```
+
+---
+
+### Task 6: Dark Mode Particles — Stars and Shooting Stars
+
+**Files:**
+- Modify: `src/components/Particles.astro`
+
+**Step 1: Rewrite Particles.astro to branch on theme**
+
+Replace the entire `<script>` content with:
+
+```astro
+---
+---
+
+<script>
+  function spawnEffects() {
+    var container = document.getElementById('particles');
+    if (!container) return;
+
+    while (container.firstChild) {
+      container.removeChild(container.firstChild);
+    }
+
+    var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+
+    if (isDark) {
+      spawnStars(container);
+      scheduleShootingStar(container);
+    } else {
+      spawnFireflies(container);
+    }
+
+    spawnRipples(container);
+  }
+
+  function spawnFireflies(container) {
+    var count = Math.min(10, Math.floor(window.innerWidth / 140));
+    for (var i = 0; i < count; i++) {
+      var f = document.createElement('div');
+      f.className = 'firefly';
+      f.style.left = (5 + Math.random() * 90) + '%';
+      f.style.top = (10 + Math.random() * 80) + '%';
+      f.style.animationDuration = (4 + Math.random() * 6) + 's';
+      f.style.animationDelay = (Math.random() * 8) + 's';
+      f.style.setProperty('--wander-x', (-30 + Math.random() * 60) + 'px');
+      f.style.setProperty('--wander-y', (-20 + Math.random() * 40) + 'px');
+      container.appendChild(f);
+    }
+  }
+
+  function spawnStars(container) {
+    var count = 30 + Math.floor(Math.random() * 11);
+    for (var i = 0; i < count; i++) {
+      var s = document.createElement('div');
+      var isAmber = Math.random() > 0.65;
+      s.className = 'star' + (isAmber ? ' star--amber' : '');
+      var size = 1 + Math.random() * 2;
+      s.style.width = size + 'px';
+      s.style.height = size + 'px';
+      s.style.left = (Math.random() * 100) + '%';
+      s.style.top = (Math.random() * 100) + '%';
+      s.style.animationDuration = (2 + Math.random() * 4) + 's';
+      s.style.animationDelay = (Math.random() * 5) + 's';
+      container.appendChild(s);
+    }
+  }
+
+  function scheduleShootingStar(container) {
+    if (!document.getElementById('particles')) return;
+    if (document.documentElement.getAttribute('data-theme') !== 'dark') return;
+
+    setTimeout(function() {
+      if (document.documentElement.getAttribute('data-theme') !== 'dark') return;
+
+      var star = document.createElement('div');
+      star.className = 'shooting-star';
+      star.style.left = (10 + Math.random() * 60) + '%';
+      star.style.top = (5 + Math.random() * 40) + '%';
+
+      var dx = 80 + Math.random() * 120;
+      var dy = 40 + Math.random() * 80;
+      star.style.setProperty('--shoot-x', dx + 'px');
+      star.style.setProperty('--shoot-y', dy + 'px');
+      star.style.animationDuration = (1.5 + Math.random() * 1.5) + 's';
+
+      container.appendChild(star);
+      star.addEventListener('animationend', function() { star.remove(); });
+
+      scheduleShootingStar(container);
+    }, 15000 + Math.random() * 15000);
+  }
+
+  function spawnRipples(container) {
+    function spawn() {
+      if (!document.getElementById('particles')) return;
+      var r = document.createElement('div');
+      r.className = 'ripple';
+      r.style.left = (10 + Math.random() * 80) + '%';
+      r.style.top = (10 + Math.random() * 80) + '%';
+      container.appendChild(r);
+      r.addEventListener('animationend', function() { r.remove(); });
+      setTimeout(spawn, 3000 + Math.random() * 5000);
+    }
+    setTimeout(spawn, 1000 + Math.random() * 2000);
+  }
+
+  window.addEventListener('theme-changed', function() {
+    spawnEffects();
+  });
+
+  spawnEffects();
+  document.addEventListener('astro:after-swap', spawnEffects);
+</script>
+```
+
+**Step 2: Verify build succeeds**
+
+Run: `npm run build`
+Expected: Build completes with no errors.
+
+**Step 3: Commit**
+
+```bash
+git add src/components/Particles.astro
+git commit -m "feat: add starry sky and shooting stars for dark mode particles"
+```
+
+---
+
+### Task 7: Dark Mode Colors for All Remaining Components
+
+**Files:**
+- Modify: `src/layouts/ContentLayout.astro`
+- Modify: `src/components/Navigation.astro`
+- Modify: `src/components/Footer.astro`
+- Modify: `src/components/PillarCard.astro`
+- Modify: `src/components/QuestionCard.astro`
+- Modify: `src/components/SilenceTag.astro`
+- Modify: `src/pages/index.astro`
+
+**Step 1: ContentLayout.astro**
+
+Line 30 — the `<h1>` in the article wrapper:
+- `text-sand-800` → add `dark:text-dusk-100`
+
+**Step 2: Navigation.astro**
+
+- Line 46, section title: `text-sand-300` → add `dark:text-dusk-700`
+- Line 58, active link: `text-sand-800` → add `dark:text-dusk-100`
+- Line 59, inactive link: `text-sand-400 hover:text-sand-600` → add `dark:text-dusk-400 dark:hover:text-dusk-200`
+
+**Step 3: Footer.astro**
+
+- Line 7, border + text: `border-sand-200` → add `dark:border-dusk-800`; `text-sand-400` → add `dark:text-dusk-400`
+- Line 10, 17, 22, link hover: `hover:text-sand-600` → add `dark:hover:text-dusk-200`
+
+**Step 4: PillarCard.astro**
+
+- Line 12, title: `text-sand-800` → add `dark:text-dusk-100`; `group-hover:text-sage` → add `dark:group-hover:text-sage-light`
+- Line 15, description: `text-sand-500` → add `dark:text-dusk-400`
+
+**Step 5: QuestionCard.astro**
+
+- Line 10, border: `border-sand-100` → add `dark:border-dusk-900`
+- Line 11, text: `text-sand-700` → add `dark:text-dusk-200`
+- Line 12, stage label: `text-sand-300` → add `dark:text-dusk-700`
+
+**Step 6: SilenceTag.astro**
+
+- Line 4, borders: `border-sand-200` → add `dark:border-dusk-800`
+- Line 5, title: `text-sand-800` → add `dark:text-dusk-100`
+- Line 6, description: `text-sand-500` → add `dark:text-dusk-400`
+
+**Step 7: index.astro (homepage)**
+
+- Line 15, h1: `text-sand-800` → add `dark:text-dusk-100`
+- Line 18, subtitle: `text-sand-400` → add `dark:text-dusk-400`
+- Line 23, 41, 63, 78 — dividers: `border-sand-200` → add `dark:border-dusk-800`
+- Line 27, body text: `text-sand-600` → add `dark:text-dusk-300`
+- Line 35, emphasis: `text-sand-800` → add `dark:text-dusk-100`
+- Lines 68, 83 — CTA links: `text-sand-800` → add `dark:text-dusk-100`; `hover:text-sage` → add `dark:hover:text-sage-light`
+- Lines 71, 86 — CTA arrows: `text-sand-300` → add `dark:text-dusk-700`; `group-hover:text-sage` → add `dark:group-hover:text-sage-light`
+- Lines 73, 88 — CTA subtext: `text-sand-400` → add `dark:text-dusk-400`
+
+**Step 8: Also update body background in BaseLayout.astro**
+
+- Line 46, body: `min-h-screen` → add `dark:bg-dusk-950`
+- Line 47, reading progress bar: `bg-sage/40` → add `dark:bg-sage-light/40`
+
+**Step 9: Verify build succeeds**
+
+Run: `npm run build`
+Expected: Build completes with no errors.
+
+**Step 10: Commit**
+
+```bash
+git add src/layouts/ContentLayout.astro src/components/Navigation.astro src/components/Footer.astro src/components/PillarCard.astro src/components/QuestionCard.astro src/components/SilenceTag.astro src/pages/index.astro src/layouts/BaseLayout.astro
+git commit -m "feat: add dark mode colors to all components and pages"
+```
+
+---
+
+### Task 8: Visual Verification
+
+**Step 1: Start dev server**
+
+Run: `npm run dev`
+
+**Step 2: Verify light mode is unchanged**
+
+Open browser. The site should look exactly the same as before — no visual regressions.
+
+**Step 3: Toggle to dark mode**
+
+Click the campfire icon. Verify:
+- Background shifts to deep warm dark (#141311)
+- Text shifts to light sand tones
+- Stars twinkle in the background
+- A shooting star appears within 15-30 seconds
+- Ripples shift to moonlit silver
+- Campfire icon swaps to stars icon
+- Navigation, footer, prose content all use dark palette
+
+**Step 4: Verify persistence**
+
+Refresh the page. Dark mode should persist (no flash of light mode).
+
+**Step 5: Verify system preference fallback**
+
+Clear localStorage. Set OS to dark mode. Reload — site should be dark. Set OS to light — site should be light.
+
+**Step 6: Check all pages**
+
+Navigate through: homepage, a pillar page (Walk), a guide page, questions page, an ethos page. All should display correctly in both modes.
+
+**Step 7: Commit (if any fixes needed)**
+
+```bash
+git add -A
+git commit -m "fix: dark mode visual polish and adjustments"
+```
+
+---
+
+### Summary of All Files Touched
+
+| File | Action |
+|------|--------|
+| `tailwind.config.mjs` | Modify — add darkMode, dusk palette, sage object |
+| `src/styles/global.css` | Modify — dark base, star keyframes, prose overrides |
+| `src/layouts/BaseLayout.astro` | Modify — data-theme attr, flash script, dark body |
+| `src/components/ThemeToggle.astro` | Create — campfire/stars toggle |
+| `src/components/Header.astro` | Modify — import toggle, dark colors |
+| `src/components/Particles.astro` | Modify — star/shooting-star spawning |
+| `src/layouts/ContentLayout.astro` | Modify — dark heading color |
+| `src/components/Navigation.astro` | Modify — dark nav colors |
+| `src/components/Footer.astro` | Modify — dark footer colors |
+| `src/components/PillarCard.astro` | Modify — dark card colors |
+| `src/components/QuestionCard.astro` | Modify — dark card colors |
+| `src/components/SilenceTag.astro` | Modify — dark aside colors |
+| `src/pages/index.astro` | Modify — dark homepage colors |

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -4,7 +4,7 @@ const base = import.meta.env.BASE_URL;
 
 <footer class="mt-32 mb-16">
   <div class="max-w-wide mx-auto px-6">
-    <div class="border-t border-sand-200 dark:border-dusk-800 pt-8 font-ui text-xs text-sand-400 dark:text-dusk-400 flex justify-between items-center">
+    <div class="border-t border-sand-200 dark:border-dusk-800 pt-8 font-ui text-xs text-sand-400 dark:text-dusk-300 flex justify-between items-center">
       <span>walk · talk · meditate</span>
       <div class="flex gap-5 items-center">
         <a href={`${base}ethos/open-source/`} class="hover:text-sand-600 dark:hover:text-dusk-200 transition-colors" aria-label="Open source ethos">

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -4,22 +4,22 @@ const base = import.meta.env.BASE_URL;
 
 <footer class="mt-32 mb-16">
   <div class="max-w-wide mx-auto px-6">
-    <div class="border-t border-sand-200 pt-8 font-ui text-xs text-sand-400 flex justify-between items-center">
+    <div class="border-t border-sand-200 dark:border-dusk-800 pt-8 font-ui text-xs text-sand-400 dark:text-dusk-400 flex justify-between items-center">
       <span>walk · talk · meditate</span>
       <div class="flex gap-5 items-center">
-        <a href={`${base}ethos/open-source/`} class="hover:text-sand-600 transition-colors" aria-label="Open source ethos">
+        <a href={`${base}ethos/open-source/`} class="hover:text-sand-600 dark:hover:text-dusk-200 transition-colors" aria-label="Open source ethos">
           <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="10" />
             <path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20" />
             <path d="M2 12h20" />
           </svg>
         </a>
-        <a href="https://github.com/orgs/walktalkmeditate/discussions" class="hover:text-sand-600 transition-colors" aria-label="Community discussions">
+        <a href="https://github.com/orgs/walktalkmeditate/discussions" class="hover:text-sand-600 dark:hover:text-dusk-200 transition-colors" aria-label="Community discussions">
           <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
             <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
           </svg>
         </a>
-        <a href="https://github.com/walktalkmeditate/walktalkmeditate" class="hover:text-sand-600 transition-colors" aria-label="GitHub repository">
+        <a href="https://github.com/walktalkmeditate/walktalkmeditate" class="hover:text-sand-600 dark:hover:text-dusk-200 transition-colors" aria-label="GitHub repository">
           <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
             <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/>
           </svg>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,4 +1,5 @@
 ---
+import ThemeToggle from './ThemeToggle.astro';
 const base = import.meta.env.BASE_URL;
 
 const navItems = [
@@ -15,30 +16,34 @@ const navItems = [
   <nav class="max-w-wide mx-auto px-6 flex items-center justify-between">
     <a href={`${base}`} class="flex items-center gap-3 hover:opacity-70 transition-opacity" transition:name="site-title">
       <img src={`${base}logo-32.png`} alt="" width="28" height="28" class="opacity-80" />
-      <span class="font-heading text-lg md:text-xl text-sand-800 tracking-display">
+      <span class="font-heading text-lg md:text-xl text-sand-800 dark:text-dusk-100 tracking-display">
         walk <span class="breathing-dot"></span> talk <span class="breathing-dot"></span> meditate
       </span>
     </a>
 
-    <button
-      id="menu-toggle"
-      class="md:hidden p-2 text-sand-400 hover:text-sand-600"
-      aria-label="Toggle menu"
-      aria-expanded="false"
-    >
-      <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1" d="M4 6h16M4 12h16M4 18h16" />
-      </svg>
-    </button>
+    <div class="flex items-center gap-2 md:hidden">
+      <ThemeToggle />
+      <button
+        id="menu-toggle"
+        class="p-2 text-sand-400 hover:text-sand-600 dark:text-dusk-400 dark:hover:text-dusk-200"
+        aria-label="Toggle menu"
+        aria-expanded="false"
+      >
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+      </button>
+    </div>
 
     <ul class="hidden md:flex items-center gap-8 font-ui text-[13px] tracking-wide">
       {navItems.map(item => (
         <li>
-          <a href={item.href} class="nav-link text-sand-400 hover:text-sand-700 transition-colors">
+          <a href={item.href} class="nav-link text-sand-400 hover:text-sand-700 dark:text-dusk-400 dark:hover:text-dusk-200 transition-colors">
             {item.label}
           </a>
         </li>
       ))}
+      <li><ThemeToggle /></li>
     </ul>
   </nav>
 
@@ -46,7 +51,7 @@ const navItems = [
     <ul class="max-w-wide mx-auto px-6 pt-4 pb-2 space-y-2 font-ui text-sm">
       {navItems.map(item => (
         <li>
-          <a href={item.href} class="block text-sand-400 hover:text-sand-700 transition-colors py-1">
+          <a href={item.href} class="block text-sand-400 hover:text-sand-700 dark:text-dusk-400 dark:hover:text-dusk-200 transition-colors py-1">
             {item.label}
           </a>
         </li>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -66,7 +66,7 @@ const navItems = [
     left: 0;
     width: 0;
     height: 1px;
-    background: theme('colors.sage');
+    background: theme('colors.sage.DEFAULT');
     transition: width 0.3s ease;
   }
   .nav-link:hover::after {

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,5 +1,4 @@
 ---
-import ThemeToggle from './ThemeToggle.astro';
 const base = import.meta.env.BASE_URL;
 
 const navItems = [
@@ -15,35 +14,31 @@ const navItems = [
 <header class="pt-8 pb-6 md:pt-12 md:pb-8">
   <nav class="max-w-wide mx-auto px-6 flex items-center justify-between">
     <a href={`${base}`} class="flex items-center gap-3 hover:opacity-70 transition-opacity" transition:name="site-title">
-      <img src={`${base}logo-32.png`} alt="" width="28" height="28" class="opacity-80" />
+      <img src={`${base}logo-32.png`} alt="" width="28" height="28" class="opacity-80 dark:invert" />
       <span class="font-heading text-lg md:text-xl text-sand-800 dark:text-dusk-100 tracking-display">
         walk <span class="breathing-dot"></span> talk <span class="breathing-dot"></span> meditate
       </span>
     </a>
 
-    <div class="flex items-center gap-2 md:hidden">
-      <ThemeToggle />
-      <button
-        id="menu-toggle"
-        class="p-2 text-sand-400 hover:text-sand-600 dark:text-dusk-400 dark:hover:text-dusk-200"
-        aria-label="Toggle menu"
-        aria-expanded="false"
-      >
-        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-      </button>
-    </div>
+    <button
+      id="menu-toggle"
+      class="md:hidden p-2 text-sand-400 hover:text-sand-600 dark:text-dusk-300 dark:hover:text-dusk-200"
+      aria-label="Toggle menu"
+      aria-expanded="false"
+    >
+      <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1" d="M4 6h16M4 12h16M4 18h16" />
+      </svg>
+    </button>
 
     <ul class="hidden md:flex items-center gap-8 font-ui text-[13px] tracking-wide">
       {navItems.map(item => (
         <li>
-          <a href={item.href} class="nav-link text-sand-400 hover:text-sand-700 dark:text-dusk-400 dark:hover:text-dusk-200 transition-colors">
+          <a href={item.href} class="nav-link text-sand-400 hover:text-sand-700 dark:text-dusk-300 dark:hover:text-dusk-200 transition-colors">
             {item.label}
           </a>
         </li>
       ))}
-      <li><ThemeToggle /></li>
     </ul>
   </nav>
 
@@ -51,7 +46,7 @@ const navItems = [
     <ul class="max-w-wide mx-auto px-6 pt-4 pb-2 space-y-2 font-ui text-sm">
       {navItems.map(item => (
         <li>
-          <a href={item.href} class="block text-sand-400 hover:text-sand-700 dark:text-dusk-400 dark:hover:text-dusk-200 transition-colors py-1">
+          <a href={item.href} class="block text-sand-400 hover:text-sand-700 dark:text-dusk-300 dark:hover:text-dusk-200 transition-colors py-1">
             {item.label}
           </a>
         </li>

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -55,7 +55,7 @@ const currentPath = Astro.url.pathname;
               'block font-ui text-[13px] transition-colors',
               currentPath.endsWith(item.href.replace(/\/$/, '') + '/') || currentPath.endsWith(item.href.replace(/\/$/, ''))
                 ? 'text-sand-800 dark:text-dusk-100'
-                : 'text-sand-400 dark:text-dusk-400 hover:text-sand-600 dark:hover:text-dusk-200',
+                : 'text-sand-400 dark:text-dusk-300 hover:text-sand-600 dark:hover:text-dusk-200',
             ]}
           >
             {item.label}

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -43,7 +43,7 @@ const currentPath = Astro.url.pathname;
 
 <aside class="hidden lg:block w-40 shrink-0 pt-3">
   <nav class="sticky top-12">
-    <p class="font-ui text-[11px] uppercase tracking-[0.15em] text-sand-300 mb-5">
+    <p class="font-ui text-[11px] uppercase tracking-[0.15em] text-sand-300 dark:text-dusk-700 mb-5">
       {current.title}
     </p>
     <ul class="space-y-2">
@@ -54,8 +54,8 @@ const currentPath = Astro.url.pathname;
             class:list={[
               'block font-ui text-[13px] transition-colors',
               currentPath.endsWith(item.href.replace(/\/$/, '') + '/') || currentPath.endsWith(item.href.replace(/\/$/, ''))
-                ? 'text-sand-800'
-                : 'text-sand-400 hover:text-sand-600',
+                ? 'text-sand-800 dark:text-dusk-100'
+                : 'text-sand-400 dark:text-dusk-400 hover:text-sand-600 dark:hover:text-dusk-200',
             ]}
           >
             {item.label}

--- a/src/components/Particles.astro
+++ b/src/components/Particles.astro
@@ -21,7 +21,7 @@
     }
   }
 
-  function spawnFireflies(container) {
+  function spawnFireflies(container: HTMLElement) {
     var count = Math.min(10, Math.floor(window.innerWidth / 140));
     for (var i = 0; i < count; i++) {
       var f = document.createElement('div');
@@ -36,7 +36,7 @@
     }
   }
 
-  function spawnStars(container) {
+  function spawnStars(container: HTMLElement) {
     var count = 30 + Math.floor(Math.random() * 11);
     for (var i = 0; i < count; i++) {
       var s = document.createElement('div');
@@ -53,7 +53,7 @@
     }
   }
 
-  function scheduleShootingStar(container) {
+  function scheduleShootingStar(container: HTMLElement) {
     if (!document.getElementById('particles')) return;
     if (document.documentElement.getAttribute('data-theme') !== 'dark') return;
 
@@ -78,7 +78,7 @@
     }, 15000 + Math.random() * 15000);
   }
 
-  function spawnRipples(container) {
+  function spawnRipples(container: HTMLElement) {
     function spawn() {
       if (!document.getElementById('particles')) return;
       var r = document.createElement('div');
@@ -97,9 +97,10 @@
     if (container) {
       container.style.transition = 'opacity 0.4s ease';
       container.style.opacity = '0';
+      var el = container;
       setTimeout(function() {
         spawnEffects();
-        container.style.opacity = '1';
+        el.style.opacity = '1';
       }, 400);
     }
   });

--- a/src/components/Particles.astro
+++ b/src/components/Particles.astro
@@ -17,9 +17,8 @@
       scheduleShootingStar(container);
     } else {
       spawnFireflies(container);
+      spawnRipples(container);
     }
-
-    spawnRipples(container);
   }
 
   function spawnFireflies(container) {
@@ -94,7 +93,15 @@
   }
 
   window.addEventListener('theme-changed', function() {
-    spawnEffects();
+    var container = document.getElementById('particles');
+    if (container) {
+      container.style.transition = 'opacity 0.4s ease';
+      container.style.opacity = '0';
+      setTimeout(function() {
+        spawnEffects();
+        container.style.opacity = '1';
+      }, 400);
+    }
   });
 
   spawnEffects();

--- a/src/components/Particles.astro
+++ b/src/components/Particles.astro
@@ -3,40 +3,99 @@
 
 <script>
   function spawnEffects() {
-    const container = document.getElementById('particles');
+    var container = document.getElementById('particles');
     if (!container) return;
 
     while (container.firstChild) {
       container.removeChild(container.firstChild);
     }
 
-    // Fireflies
-    const fireflyCount = Math.min(10, Math.floor(window.innerWidth / 140));
-    for (let i = 0; i < fireflyCount; i++) {
-      const f = document.createElement('div');
-      f.className = 'firefly';
-      f.style.left = `${5 + Math.random() * 90}%`;
-      f.style.top = `${10 + Math.random() * 80}%`;
-      f.style.animationDuration = `${4 + Math.random() * 6}s`;
-      f.style.animationDelay = `${Math.random() * 8}s`;
-      f.style.setProperty('--wander-x', `${-30 + Math.random() * 60}px`);
-      f.style.setProperty('--wander-y', `${-20 + Math.random() * 40}px`);
-      container.appendChild(f);
+    var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+
+    if (isDark) {
+      spawnStars(container);
+      scheduleShootingStar(container);
+    } else {
+      spawnFireflies(container);
     }
 
-    // Ripples
-    function spawnRipple() {
-      if (!document.getElementById('particles')) return;
-      const r = document.createElement('div');
-      r.className = 'ripple';
-      r.style.left = `${10 + Math.random() * 80}%`;
-      r.style.top = `${10 + Math.random() * 80}%`;
-      container.appendChild(r);
-      r.addEventListener('animationend', () => r.remove());
-      setTimeout(spawnRipple, 3000 + Math.random() * 5000);
-    }
-    setTimeout(spawnRipple, 1000 + Math.random() * 2000);
+    spawnRipples(container);
   }
+
+  function spawnFireflies(container) {
+    var count = Math.min(10, Math.floor(window.innerWidth / 140));
+    for (var i = 0; i < count; i++) {
+      var f = document.createElement('div');
+      f.className = 'firefly';
+      f.style.left = (5 + Math.random() * 90) + '%';
+      f.style.top = (10 + Math.random() * 80) + '%';
+      f.style.animationDuration = (4 + Math.random() * 6) + 's';
+      f.style.animationDelay = (Math.random() * 8) + 's';
+      f.style.setProperty('--wander-x', (-30 + Math.random() * 60) + 'px');
+      f.style.setProperty('--wander-y', (-20 + Math.random() * 40) + 'px');
+      container.appendChild(f);
+    }
+  }
+
+  function spawnStars(container) {
+    var count = 30 + Math.floor(Math.random() * 11);
+    for (var i = 0; i < count; i++) {
+      var s = document.createElement('div');
+      var isAmber = Math.random() > 0.65;
+      s.className = 'star' + (isAmber ? ' star--amber' : '');
+      var size = 1 + Math.random() * 2;
+      s.style.width = size + 'px';
+      s.style.height = size + 'px';
+      s.style.left = (Math.random() * 100) + '%';
+      s.style.top = (Math.random() * 100) + '%';
+      s.style.animationDuration = (2 + Math.random() * 4) + 's';
+      s.style.animationDelay = (Math.random() * 5) + 's';
+      container.appendChild(s);
+    }
+  }
+
+  function scheduleShootingStar(container) {
+    if (!document.getElementById('particles')) return;
+    if (document.documentElement.getAttribute('data-theme') !== 'dark') return;
+
+    setTimeout(function() {
+      if (document.documentElement.getAttribute('data-theme') !== 'dark') return;
+
+      var star = document.createElement('div');
+      star.className = 'shooting-star';
+      star.style.left = (10 + Math.random() * 60) + '%';
+      star.style.top = (5 + Math.random() * 40) + '%';
+
+      var dx = 80 + Math.random() * 120;
+      var dy = 40 + Math.random() * 80;
+      star.style.setProperty('--shoot-x', dx + 'px');
+      star.style.setProperty('--shoot-y', dy + 'px');
+      star.style.animationDuration = (1.5 + Math.random() * 1.5) + 's';
+
+      container.appendChild(star);
+      star.addEventListener('animationend', function() { star.remove(); });
+
+      scheduleShootingStar(container);
+    }, 15000 + Math.random() * 15000);
+  }
+
+  function spawnRipples(container) {
+    function spawn() {
+      if (!document.getElementById('particles')) return;
+      var r = document.createElement('div');
+      r.className = 'ripple';
+      r.style.left = (10 + Math.random() * 80) + '%';
+      r.style.top = (10 + Math.random() * 80) + '%';
+      container.appendChild(r);
+      r.addEventListener('animationend', function() { r.remove(); });
+      setTimeout(spawn, 3000 + Math.random() * 5000);
+    }
+    setTimeout(spawn, 1000 + Math.random() * 2000);
+  }
+
+  window.addEventListener('theme-changed', function() {
+    spawnEffects();
+  });
 
   spawnEffects();
   document.addEventListener('astro:after-swap', spawnEffects);

--- a/src/components/PillarCard.astro
+++ b/src/components/PillarCard.astro
@@ -12,5 +12,5 @@ const { title, description, href } = Astro.props;
   <h3 class="font-heading text-3xl md:text-4xl font-light text-sand-800 dark:text-dusk-100 group-hover:text-sage dark:group-hover:text-sage-light transition-colors tracking-display mb-4">
     {title}
   </h3>
-  <p class="text-sand-500 dark:text-dusk-400 leading-relaxed text-base">{description}</p>
+  <p class="text-sand-500 dark:text-dusk-300 leading-relaxed text-base">{description}</p>
 </a>

--- a/src/components/PillarCard.astro
+++ b/src/components/PillarCard.astro
@@ -9,8 +9,8 @@ const { title, description, href } = Astro.props;
 ---
 
 <a href={href} class="group block">
-  <h3 class="font-heading text-3xl md:text-4xl font-light text-sand-800 group-hover:text-sage transition-colors tracking-display mb-4">
+  <h3 class="font-heading text-3xl md:text-4xl font-light text-sand-800 dark:text-dusk-100 group-hover:text-sage dark:group-hover:text-sage-light transition-colors tracking-display mb-4">
     {title}
   </h3>
-  <p class="text-sand-500 leading-relaxed text-base">{description}</p>
+  <p class="text-sand-500 dark:text-dusk-400 leading-relaxed text-base">{description}</p>
 </a>

--- a/src/components/QuestionCard.astro
+++ b/src/components/QuestionCard.astro
@@ -7,9 +7,9 @@ interface Props {
 const { text, stage } = Astro.props;
 ---
 
-<div class="py-6 border-b border-sand-100 last:border-0">
-  <p class="font-body text-lg text-sand-700 leading-relaxed">{text}</p>
-  <span class="inline-block mt-3 font-ui text-[11px] uppercase tracking-[0.15em] text-sand-300">
+<div class="py-6 border-b border-sand-100 dark:border-dusk-900 last:border-0">
+  <p class="font-body text-lg text-sand-700 dark:text-dusk-200 leading-relaxed">{text}</p>
+  <span class="inline-block mt-3 font-ui text-[11px] uppercase tracking-[0.15em] text-sand-300 dark:text-dusk-700">
     {stage}
   </span>
 </div>

--- a/src/components/SilenceTag.astro
+++ b/src/components/SilenceTag.astro
@@ -1,9 +1,9 @@
 ---
 ---
 
-<aside class="my-12 py-8 border-t border-b border-sand-200">
-  <p class="font-heading text-xl text-sand-800 mb-2 tracking-display">The "In Silence" Tag</p>
-  <p class="text-sand-500 text-base leading-relaxed max-w-prose">
+<aside class="my-12 py-8 border-t border-b border-sand-200 dark:border-dusk-800">
+  <p class="font-heading text-xl text-sand-800 dark:text-dusk-100 mb-2 tracking-display">The "In Silence" Tag</p>
+  <p class="text-sand-500 dark:text-dusk-400 text-base leading-relaxed max-w-prose">
     Wear it to signal you'd like silence. Everyone respects it — no explanation needed.
     Remove it when you're ready to talk again. A concrete expression of the golden rule.
   </p>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -1,0 +1,61 @@
+---
+---
+
+<button
+  id="theme-toggle"
+  class="p-2 text-sand-400 hover:text-sand-600 dark:text-dusk-400 dark:hover:text-dusk-200 transition-colors"
+  aria-label="Toggle theme"
+>
+  <svg id="icon-campfire" class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M12 3c-1 4-4 6-4 10a4 4 0 0 0 8 0c0-4-3-6-4-10z" />
+    <path d="M8 21h8" />
+    <path d="M6 21l2-4" />
+    <path d="M18 21l-2-4" />
+  </svg>
+  <svg id="icon-stars" class="w-5 h-5 hidden" viewBox="0 0 24 24" fill="currentColor" stroke="none">
+    <circle cx="6" cy="6" r="1.5" />
+    <circle cx="18" cy="4" r="1" />
+    <circle cx="14" cy="10" r="1.5" />
+    <circle cx="4" cy="14" r="1" />
+    <circle cx="20" cy="16" r="1.5" />
+    <circle cx="10" cy="18" r="1" />
+  </svg>
+</button>
+
+<script>
+  function initThemeToggle() {
+    const btn = document.getElementById('theme-toggle');
+    const iconCampfire = document.getElementById('icon-campfire');
+    const iconStars = document.getElementById('icon-stars');
+    if (!btn || !iconCampfire || !iconStars) return;
+
+    function updateIcons() {
+      var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+      iconCampfire.classList.toggle('hidden', isDark);
+      iconStars.classList.toggle('hidden', !isDark);
+    }
+
+    updateIcons();
+
+    btn.addEventListener('click', function() {
+      var current = document.documentElement.getAttribute('data-theme');
+      var next = current === 'dark' ? 'light' : 'dark';
+      document.documentElement.setAttribute('data-theme', next);
+      localStorage.setItem('theme', next);
+      updateIcons();
+      window.dispatchEvent(new CustomEvent('theme-changed', { detail: { theme: next } }));
+    });
+  }
+
+  initThemeToggle();
+  document.addEventListener('astro:after-swap', initThemeToggle);
+</script>
+
+<style>
+  #theme-toggle {
+    transition: transform 0.2s ease, opacity 0.2s ease;
+  }
+  #theme-toggle:active {
+    transform: scale(0.9);
+  }
+</style>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -31,8 +31,8 @@
 
     function updateIcons() {
       var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-      iconCampfire.classList.toggle('hidden', isDark);
-      iconStars.classList.toggle('hidden', !isDark);
+      iconCampfire!.classList.toggle('hidden', isDark);
+      iconStars!.classList.toggle('hidden', !isDark);
     }
 
     updateIcons();

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -3,7 +3,7 @@
 
 <button
   id="theme-toggle"
-  class="p-2 text-sand-400 hover:text-sand-600 dark:text-dusk-400 dark:hover:text-dusk-200 transition-colors"
+  class="p-2 text-sand-400 hover:text-sand-600 dark:text-dusk-300 dark:hover:text-dusk-100 transition-colors"
   aria-label="Toggle theme"
 >
   <svg id="icon-campfire" class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
@@ -40,10 +40,14 @@
     btn.addEventListener('click', function() {
       var current = document.documentElement.getAttribute('data-theme');
       var next = current === 'dark' ? 'light' : 'dark';
+      document.documentElement.classList.add('theme-transition');
       document.documentElement.setAttribute('data-theme', next);
       localStorage.setItem('theme', next);
       updateIcons();
       window.dispatchEvent(new CustomEvent('theme-changed', { detail: { theme: next } }));
+      setTimeout(function() {
+        document.documentElement.classList.remove('theme-transition');
+      }, 700);
     });
   }
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -13,7 +13,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -42,9 +42,17 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
     <ViewTransitions />
     <title>{title}</title>
+    <script is:inline>
+      (function() {
+        var stored = localStorage.getItem('theme');
+        var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        var theme = stored || (prefersDark ? 'dark' : 'light');
+        document.documentElement.setAttribute('data-theme', theme);
+      })();
+    </script>
   </head>
-  <body class="min-h-screen">
-    <div id="reading-progress" class="fixed top-0 left-0 h-[1px] bg-sage/40 z-[100] transition-none" style="width: 0%" />
+  <body class="min-h-screen dark:bg-dusk-950">
+    <div id="reading-progress" class="fixed top-0 left-0 h-[1px] bg-sage/40 dark:bg-sage-light/40 z-[100] transition-none" style="width: 0%" />
     <div id="particles" class="fixed inset-0 pointer-events-none z-0 overflow-hidden" aria-hidden="true" />
     <Particles />
     <div class="relative z-10">

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -2,6 +2,7 @@
 import { ViewTransitions } from 'astro:transitions';
 import '../styles/global.css';
 import Particles from '../components/Particles.astro';
+import ThemeToggle from '../components/ThemeToggle.astro';
 
 interface Props {
   title: string;
@@ -48,15 +49,43 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
         var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
         var theme = stored || (prefersDark ? 'dark' : 'light');
         document.documentElement.setAttribute('data-theme', theme);
+
+        var originalFavicon = document.querySelector('link[rel="icon"]').getAttribute('href');
+        window.__updateFavicon = function(isDark) {
+          var link = document.querySelector('link[rel="icon"]');
+          if (!link) return;
+          var img = new Image();
+          img.crossOrigin = 'anonymous';
+          img.onload = function() {
+            var c = document.createElement('canvas');
+            c.width = img.width;
+            c.height = img.height;
+            var ctx = c.getContext('2d');
+            if (isDark) {
+              ctx.filter = 'invert(1)';
+            }
+            ctx.drawImage(img, 0, 0);
+            link.href = c.toDataURL('image/png');
+          };
+          img.src = originalFavicon;
+        };
+        window.__updateFavicon(theme === 'dark');
+
+        window.addEventListener('theme-changed', function(e) {
+          window.__updateFavicon(e.detail.theme === 'dark');
+        });
       })();
     </script>
   </head>
-  <body class="min-h-screen dark:bg-dusk-950">
+  <body class="min-h-screen">
     <div id="reading-progress" class="fixed top-0 left-0 h-[1px] bg-sage/40 dark:bg-sage-light/40 z-[100] transition-none" style="width: 0%" />
     <div id="particles" class="fixed inset-0 pointer-events-none z-0 overflow-hidden" aria-hidden="true" />
     <Particles />
     <div class="relative z-10">
       <slot />
+    </div>
+    <div class="fixed bottom-6 right-6 z-50">
+      <ThemeToggle />
     </div>
 
     <script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,5 @@
 ---
-import { ViewTransitions } from 'astro:transitions';
+import { ClientRouter } from 'astro:transitions';
 import '../styles/global.css';
 import Particles from '../components/Particles.astro';
 import ThemeToggle from '../components/ThemeToggle.astro';
@@ -41,7 +41,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
       rel="stylesheet"
     />
 
-    <ViewTransitions />
+    <ClientRouter />
     <title>{title}</title>
     <script is:inline>
       (function() {

--- a/src/layouts/ContentLayout.astro
+++ b/src/layouts/ContentLayout.astro
@@ -27,7 +27,7 @@ const section = Astro.props.section ?? fm?.section;
     <div class:list={['flex gap-20', section ? '' : 'justify-center']}>
       {section && <Navigation section={section} />}
       <article class="prose-content min-w-0 flex-1">
-        <h1 class="mb-12 text-sand-800">{title}</h1>
+        <h1 class="mb-12 text-sand-800 dark:text-dusk-100">{title}</h1>
         <slot />
       </article>
     </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,33 +12,33 @@ const base = import.meta.env.BASE_URL;
 
   <main class="max-w-wide mx-auto px-6">
     <section class="pt-16 pb-24 md:pt-28 md:pb-36">
-      <h1 class="font-heading text-5xl sm:text-6xl md:text-[5.5rem] font-light text-sand-800 tracking-display leading-[1.05]">
+      <h1 class="font-heading text-5xl sm:text-6xl md:text-[5.5rem] font-light text-sand-800 dark:text-dusk-100 tracking-display leading-[1.05]">
         walk · talk · meditate
       </h1>
-      <p class="mt-6 text-xl md:text-2xl text-sand-400 font-heading font-light leading-relaxed max-w-lg">
+      <p class="mt-6 text-xl md:text-2xl text-sand-400 dark:text-dusk-400 font-heading font-light leading-relaxed max-w-lg">
         An open-source pilgrimage framework.
       </p>
     </section>
 
-    <div class="border-t border-sand-200" />
+    <div class="border-t border-sand-200 dark:border-dusk-800" />
 
     <section class="py-20 md:py-28 reveal">
       <div class="max-w-prose">
-        <p class="text-sand-600 text-lg leading-relaxed">
+        <p class="text-sand-600 dark:text-dusk-300 text-lg leading-relaxed">
           Inspired by the walk-and-talk tradition — small group walks with deep
           conversations. Adding meditation as an equal third pillar transforms it
           into something more: a pilgrimage anyone can take, solo or with a group,
           local or abroad.
         </p>
-        <p class="mt-6 text-sand-600 text-lg leading-relaxed">
+        <p class="mt-6 text-sand-600 dark:text-dusk-300 text-lg leading-relaxed">
           This is not another travel destination optimized for sightseeing.
-          <span class="text-sand-800">Slow and chill is the motto. Relax and release
+          <span class="text-sand-800 dark:text-dusk-100">Slow and chill is the motto. Relax and release
           is the practice. Peace and harmony is the way.</span>
         </p>
       </div>
     </section>
 
-    <div class="border-t border-sand-200" />
+    <div class="border-t border-sand-200 dark:border-dusk-800" />
 
     <section class="py-20 md:py-28 reveal">
       <div class="grid md:grid-cols-3 gap-12 md:gap-16">
@@ -60,32 +60,32 @@ const base = import.meta.env.BASE_URL;
       </div>
     </section>
 
-    <div class="border-t border-sand-200" />
+    <div class="border-t border-sand-200 dark:border-dusk-800" />
 
     <section class="py-20 md:py-28 reveal">
       <a
         href={`${base}guide/getting-started/`}
-        class="group inline-flex items-center gap-3 font-heading text-2xl md:text-3xl font-light text-sand-800 hover:text-sage transition-colors tracking-display"
+        class="group inline-flex items-center gap-3 font-heading text-2xl md:text-3xl font-light text-sand-800 dark:text-dusk-100 hover:text-sage dark:hover:text-sage-light transition-colors tracking-display"
       >
         Start your pilgrimage
-        <span class="text-sand-300 group-hover:text-sage group-hover:translate-x-1 transition-all">→</span>
+        <span class="text-sand-300 dark:text-dusk-700 group-hover:text-sage dark:group-hover:text-sage-light group-hover:translate-x-1 transition-all">→</span>
       </a>
-      <p class="mt-4 text-sand-400 font-ui text-sm">
+      <p class="mt-4 text-sand-400 dark:text-dusk-400 font-ui text-sm">
         No gear required. Start tomorrow in your own town.
       </p>
     </section>
 
-    <div class="border-t border-sand-200" />
+    <div class="border-t border-sand-200 dark:border-dusk-800" />
 
     <section class="py-20 md:py-28 reveal">
       <a
         href="https://github.com/orgs/walktalkmeditate/discussions"
-        class="group inline-flex items-center gap-3 font-heading text-2xl md:text-3xl font-light text-sand-800 hover:text-sage transition-colors tracking-display"
+        class="group inline-flex items-center gap-3 font-heading text-2xl md:text-3xl font-light text-sand-800 dark:text-dusk-100 hover:text-sage dark:hover:text-sage-light transition-colors tracking-display"
       >
         Join the community
-        <span class="text-sand-300 group-hover:text-sage group-hover:translate-x-1 transition-all">→</span>
+        <span class="text-sand-300 dark:text-dusk-700 group-hover:text-sage dark:group-hover:text-sage-light group-hover:translate-x-1 transition-all">→</span>
       </a>
-      <p class="mt-4 text-sand-400 font-ui text-sm">
+      <p class="mt-4 text-sand-400 dark:text-dusk-400 font-ui text-sm">
         Find fellow pilgrims. Organize a walk. Share your story.
       </p>
     </section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,7 +15,7 @@ const base = import.meta.env.BASE_URL;
       <h1 class="font-heading text-5xl sm:text-6xl md:text-[5.5rem] font-light text-sand-800 dark:text-dusk-100 tracking-display leading-[1.05]">
         walk · talk · meditate
       </h1>
-      <p class="mt-6 text-xl md:text-2xl text-sand-400 dark:text-dusk-400 font-heading font-light leading-relaxed max-w-lg">
+      <p class="mt-6 text-xl md:text-2xl text-sand-400 dark:text-dusk-300 font-heading font-light leading-relaxed max-w-lg">
         An open-source pilgrimage framework.
       </p>
     </section>
@@ -24,13 +24,13 @@ const base = import.meta.env.BASE_URL;
 
     <section class="py-20 md:py-28 reveal">
       <div class="max-w-prose">
-        <p class="text-sand-600 dark:text-dusk-300 text-lg leading-relaxed">
+        <p class="text-sand-600 dark:text-dusk-200 text-lg leading-relaxed">
           Inspired by the walk-and-talk tradition — small group walks with deep
           conversations. Adding meditation as an equal third pillar transforms it
           into something more: a pilgrimage anyone can take, solo or with a group,
           local or abroad.
         </p>
-        <p class="mt-6 text-sand-600 dark:text-dusk-300 text-lg leading-relaxed">
+        <p class="mt-6 text-sand-600 dark:text-dusk-200 text-lg leading-relaxed">
           This is not another travel destination optimized for sightseeing.
           <span class="text-sand-800 dark:text-dusk-100">Slow and chill is the motto. Relax and release
           is the practice. Peace and harmony is the way.</span>
@@ -70,7 +70,7 @@ const base = import.meta.env.BASE_URL;
         Start your pilgrimage
         <span class="text-sand-300 dark:text-dusk-700 group-hover:text-sage dark:group-hover:text-sage-light group-hover:translate-x-1 transition-all">→</span>
       </a>
-      <p class="mt-4 text-sand-400 dark:text-dusk-400 font-ui text-sm">
+      <p class="mt-4 text-sand-400 dark:text-dusk-300 font-ui text-sm">
         No gear required. Start tomorrow in your own town.
       </p>
     </section>
@@ -85,7 +85,7 @@ const base = import.meta.env.BASE_URL;
         Join the community
         <span class="text-sand-300 dark:text-dusk-700 group-hover:text-sage dark:group-hover:text-sage-light group-hover:translate-x-1 transition-all">→</span>
       </a>
-      <p class="mt-4 text-sand-400 dark:text-dusk-400 font-ui text-sm">
+      <p class="mt-4 text-sand-400 dark:text-dusk-300 font-ui text-sm">
         Find fellow pilgrims. Organize a walk. Share your story.
       </p>
     </section>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9,8 +9,16 @@
     -webkit-font-smoothing: antialiased;
   }
 
+  html.theme-transition,
+  html.theme-transition *,
+  html.theme-transition *::before,
+  html.theme-transition *::after {
+    transition: background-color 0.6s ease, color 0.4s ease, border-color 0.4s ease, fill 0.4s ease, stroke 0.4s ease !important;
+  }
+
   [data-theme="dark"] {
-    @apply bg-dusk-950 text-dusk-200;
+    background-color: #141311;
+    color: #D4D1C7;
   }
 
   body {
@@ -22,7 +30,7 @@
   }
 
   [data-theme="dark"] ::selection {
-    @apply bg-sage-light/20;
+    background-color: rgba(143, 163, 130, 0.2);
   }
 }
 
@@ -75,7 +83,7 @@
 }
 
 [data-theme="dark"] .ripple {
-  border-color: rgba(212, 209, 199, 0.15);
+  display: none;
 }
 
 @keyframes ripple-expand {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9,12 +9,20 @@
     -webkit-font-smoothing: antialiased;
   }
 
+  [data-theme="dark"] {
+    @apply bg-dusk-950 text-dusk-200;
+  }
+
   body {
     @apply font-body text-lg leading-relaxed;
   }
 
   ::selection {
     @apply bg-sage/20;
+  }
+
+  [data-theme="dark"] ::selection {
+    @apply bg-sage-light/20;
   }
 }
 
@@ -30,6 +38,10 @@
               0 0 14px 4px rgba(212, 165, 116, 0.15);
   animation: glow ease-in-out infinite;
   opacity: 0;
+}
+
+[data-theme="dark"] .firefly {
+  display: none;
 }
 
 @keyframes glow {
@@ -62,6 +74,10 @@
   pointer-events: none;
 }
 
+[data-theme="dark"] .ripple {
+  border-color: rgba(212, 209, 199, 0.15);
+}
+
 @keyframes ripple-expand {
   0% {
     width: 0;
@@ -75,6 +91,58 @@
     width: 280px;
     height: 280px;
     opacity: 0;
+  }
+}
+
+/* ---- Stars (dark mode) ---- */
+
+.star {
+  position: absolute;
+  border-radius: 50%;
+  background: #EEECE7;
+  animation: twinkle ease-in-out infinite;
+}
+
+.star--amber {
+  background: #D4C5A0;
+}
+
+@keyframes twinkle {
+  0%, 100% {
+    opacity: 0.3;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+/* ---- Shooting stars (dark mode) ---- */
+
+.shooting-star {
+  position: absolute;
+  width: 2px;
+  height: 2px;
+  background: #EEECE7;
+  border-radius: 50%;
+  box-shadow: 0 0 4px 1px rgba(212, 197, 160, 0.6);
+  animation: shoot linear forwards;
+  opacity: 0;
+}
+
+@keyframes shoot {
+  0% {
+    opacity: 0;
+    transform: translate(0, 0);
+  }
+  5% {
+    opacity: 1;
+  }
+  70% {
+    opacity: 0.6;
+  }
+  100% {
+    opacity: 0;
+    transform: translate(var(--shoot-x), var(--shoot-y));
   }
 }
 
@@ -119,6 +187,10 @@
 
 .breathing-dot:nth-of-type(2) {
   animation-delay: 2s;
+}
+
+[data-theme="dark"] .breathing-dot {
+  background: theme('colors.dusk.400');
 }
 
 /* ---- View Transitions ---- */
@@ -236,4 +308,61 @@
 
 .prose-content td {
   @apply px-4 py-3 text-sand-700 border-b border-sand-100;
+}
+
+/* ---- Prose dark mode ---- */
+
+[data-theme="dark"] .prose-content p {
+  @apply text-dusk-200;
+}
+
+[data-theme="dark"] .prose-content h2,
+[data-theme="dark"] .prose-content h3,
+[data-theme="dark"] .prose-content h4 {
+  @apply text-dusk-100;
+}
+
+[data-theme="dark"] .prose-content ul,
+[data-theme="dark"] .prose-content ol {
+  @apply text-dusk-200;
+}
+
+[data-theme="dark"] .prose-content ul > li::marker {
+  @apply text-dusk-700;
+}
+
+[data-theme="dark"] .prose-content ol > li::marker {
+  @apply text-dusk-400;
+}
+
+[data-theme="dark"] .prose-content blockquote {
+  @apply text-dusk-400 border-dusk-700;
+}
+
+[data-theme="dark"] .prose-content blockquote p {
+  @apply text-dusk-400;
+}
+
+[data-theme="dark"] .prose-content a {
+  @apply text-dusk-100 decoration-dusk-700 hover:decoration-sage-light;
+}
+
+[data-theme="dark"] .prose-content strong {
+  @apply text-dusk-100;
+}
+
+[data-theme="dark"] .prose-content hr {
+  @apply border-dusk-800;
+}
+
+[data-theme="dark"] .prose-content thead {
+  @apply border-dusk-800;
+}
+
+[data-theme="dark"] .prose-content th {
+  @apply text-dusk-400;
+}
+
+[data-theme="dark"] .prose-content td {
+  @apply text-dusk-200 border-dusk-900;
 }

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,6 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
+  darkMode: ['selector', '[data-theme="dark"]'],
   theme: {
     extend: {
       colors: {
@@ -16,7 +17,22 @@ export default {
           800: '#2D2B28',
           900: '#1A1917',
         },
-        sage: '#7C9070',
+        dusk: {
+          100: '#EEECE7',
+          200: '#D4D1C7',
+          300: '#B5B1A4',
+          400: '#8A8578',
+          500: '#6E6A5E',
+          600: '#4A4740',
+          700: '#3D3A35',
+          800: '#2B2926',
+          900: '#1C1A17',
+          950: '#141311',
+        },
+        sage: {
+          DEFAULT: '#7C9070',
+          light: '#8FA382',
+        },
       },
       fontFamily: {
         heading: ['"Cormorant Garamond"', 'Georgia', 'serif'],


### PR DESCRIPTION
## Summary
- **Dark mode** with warm desert night palette (dusk color scale) that inverts the sand tones
- **Starry sky particles** — twinkling fixed stars + rare shooting stars replace fireflies in dark mode
- **Campfire/stars toggle** — fixed bottom-right, with smooth day-to-night color transition
- **System preference detection** with localStorage persistence and no flash of wrong theme
- **Favicon inversion** — browser tab icon adapts to current theme

## Test plan
- [ ] Verify light mode is visually unchanged from before
- [ ] Toggle dark mode via bottom-right button — colors should transition smoothly (~0.6s)
- [ ] Confirm twinkling stars appear in dark mode, fireflies in light mode
- [ ] Wait 15-30s in dark mode for a shooting star
- [ ] Verify no ripples in dark mode
- [ ] Refresh page in dark mode — should persist without flash
- [ ] Clear localStorage, set OS to dark mode, reload — should auto-detect
- [ ] Check all pages: homepage, Walk/Talk/Meditate, Guide, Questions, Ethos
- [ ] Verify favicon inverts in dark mode
- [ ] Test on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)