### PR TITLE
JSON-LD structured data + Pilgrim ecosystem integration

### DIFF
--- a/docs/superpowers/plans/2026-06-21-json-ld-and-pilgrim-ecosystem.md
+++ b/docs/superpowers/plans/2026-06-21-json-ld-and-pilgrim-ecosystem.md
@@ -1,0 +1,1064 @@
+# JSON-LD, Site Polish & Pilgrim Ecosystem — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a coherent JSON-LD `@graph` to every page of walktalkmeditate.org, plus `llms.txt`/`robots.txt`, a `/pilgrim/` companion-app bridge page, a home teaser, and a family footer — fusing walktalkmeditate and Pilgrim into one discoverable ecosystem.
+
+**Architecture:** A pure TypeScript module (`src/lib/structuredData.ts`) builds the schema.org graph from typed input; it is unit-tested with Vitest. A thin `StructuredData.astro` component serializes the graph into a `<script type="application/ld+json">` and is rendered from `BaseLayout.astro`, so every page is covered. Page-specific data (page type, breadcrumbs, question lists, how-to steps) flows in via props/frontmatter.
+
+**Tech Stack:** Astro 5, Tailwind, TypeScript, Vitest (new — for the pure graph module).
+
+## Global Constraints
+
+- Site: `https://walktalkmeditate.org` (Astro `site`, base URL is `/`).
+- Publisher identity: schema.org **Organization** named `"Walk Talk Meditate"`. No named individual.
+- **No edits to `../pilgrim-landing`.** All Pilgrim links are one-directional → `https://pilgrimapp.org`.
+- Organization `sameAs` (verbatim): `https://pilgrimapp.org`, `https://github.com/walktalkmeditate`, `https://apps.apple.com/app/pilgrim-mindful-walking/id6760921056`, `https://play.google.com/store/apps/details?id=org.walktalkmeditate.pilgrim`, `https://mastodon.social/@pilgrimage`, `https://bsky.app/profile/pilgrima.ge`, `https://www.threads.com/@pilgrima.ge`.
+- JSON-LD must survive Astro view transitions → emit with `is:inline` in `<head>`.
+- One `<script type="application/ld+json">` per page.
+- Stable `@id`s: `…/#organization`, `…/#website`, `{pageURL}#webpage`, `{pageURL}#breadcrumb`, `https://walktalkmeditate.org/pilgrim/#app`.
+- Existing conventions: `import.meta.env.BASE_URL` for internal links; no comments that restate code; kebab-case filenames; named exports; explicit return types on exported functions.
+
+## File Structure
+
+- `src/lib/structuredData.ts` — **new.** Pure graph builder + node functions + constants. No Astro imports.
+- `src/lib/structuredData.test.ts` — **new.** Vitest unit tests.
+- `vitest.config.ts` — **new.** Minimal test config.
+- `package.json` — **modify.** Add `vitest` devDep + `test` scripts.
+- `src/components/StructuredData.astro` — **new.** Serializes graph to script tag.
+- `src/layouts/BaseLayout.astro` — **modify.** Accept `structuredData` prop, render component.
+- `src/layouts/ContentLayout.astro` — **modify.** Derive breadcrumbs + page type, forward to BaseLayout.
+- `src/pages/index.astro` — **modify.** `type: 'home'` + home teaser section.
+- `src/pages/questions/index.astro` — **modify.** `type: 'collection'`.
+- `src/pages/questions/{morning,evening,solo,walking}.astro` — **modify.** `type: 'questionList'` + items.
+- `src/pages/guide/getting-started.mdx` — **modify.** Frontmatter `pageType: howto` + `howToSteps`.
+- `src/pages/pilgrim.astro` — **new.** Companion-app bridge page (`type: 'app'`).
+- `src/components/Footer.astro` — **modify.** Family links.
+- `public/llms.txt` — **new.**
+- `public/robots.txt` — **new.**
+
+---
+
+### Task 1: Vitest setup + Organization & WebSite nodes
+
+**Files:**
+- Create: `src/lib/structuredData.ts`
+- Create: `src/lib/structuredData.test.ts`
+- Create: `vitest.config.ts`
+- Modify: `package.json`
+
+**Interfaces:**
+- Produces: `SITE_URL`, `ORG_ID`, `WEBSITE_ID`, `SAME_AS: string[]`, `organizationNode(): Record<string, unknown>`, `websiteNode(): Record<string, unknown>`, `buildGraph(input: StructuredDataInput): Record<string, unknown>` (persistent nodes only at this stage), and the exported types `PageType`, `Breadcrumb`, `StructuredDataInput`.
+
+- [ ] **Step 1: Add Vitest to the project**
+
+Run:
+```bash
+npm install -D vitest@^3
+```
+
+- [ ] **Step 2: Add test scripts to `package.json`**
+
+In `package.json`, add to `"scripts"`:
+```json
+"test": "vitest run",
+"test:watch": "vitest"
+```
+
+- [ ] **Step 3: Create `vitest.config.ts`**
+
+```ts
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});
+```
+
+- [ ] **Step 4: Write the failing test**
+
+Create `src/lib/structuredData.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  organizationNode,
+  websiteNode,
+  buildGraph,
+  ORG_ID,
+  WEBSITE_ID,
+  SAME_AS,
+} from './structuredData';
+
+describe('organizationNode', () => {
+  it('is an Organization named Walk Talk Meditate with the shared @id', () => {
+    const node = organizationNode();
+    expect(node['@type']).toBe('Organization');
+    expect(node['@id']).toBe(ORG_ID);
+    expect(node.name).toBe('Walk Talk Meditate');
+  });
+
+  it('includes pilgrimapp.org in sameAs to fuse the ecosystem', () => {
+    expect(SAME_AS).toContain('https://pilgrimapp.org');
+    expect(organizationNode().sameAs).toEqual(SAME_AS);
+  });
+});
+
+describe('websiteNode', () => {
+  it('is a WebSite published by the organization', () => {
+    const node = websiteNode();
+    expect(node['@type']).toBe('WebSite');
+    expect(node['@id']).toBe(WEBSITE_ID);
+    expect(node.publisher).toEqual({ '@id': ORG_ID });
+  });
+});
+
+describe('buildGraph', () => {
+  it('always includes the organization and website nodes', () => {
+    const graph = buildGraph({
+      type: 'webpage',
+      url: 'https://walktalkmeditate.org/walk/',
+      title: 'Walk',
+      description: 'Walking as practice.',
+    }) as { '@context': string; '@graph': Array<Record<string, unknown>> };
+    expect(graph['@context']).toBe('https://schema.org');
+    const types = graph['@graph'].map((n) => n['@type']);
+    expect(types).toContain('Organization');
+    expect(types).toContain('WebSite');
+  });
+});
+```
+
+- [ ] **Step 5: Run the test to verify it fails**
+
+Run: `npm test`
+Expected: FAIL — `Failed to resolve import "./structuredData"` / module not found.
+
+- [ ] **Step 6: Create `src/lib/structuredData.ts` with constants + persistent nodes**
+
+```ts
+export const SITE_URL = 'https://walktalkmeditate.org';
+export const ORG_ID = `${SITE_URL}/#organization`;
+export const WEBSITE_ID = `${SITE_URL}/#website`;
+
+const LOGO_URL = `${SITE_URL}/logo-128.png`;
+const OG_IMAGE = `${SITE_URL}/og.png`;
+const TAGLINE = 'An open-source pilgrimage framework for walking, talking, and meditating.';
+
+export const SAME_AS: string[] = [
+  'https://pilgrimapp.org',
+  'https://github.com/walktalkmeditate',
+  'https://apps.apple.com/app/pilgrim-mindful-walking/id6760921056',
+  'https://play.google.com/store/apps/details?id=org.walktalkmeditate.pilgrim',
+  'https://mastodon.social/@pilgrimage',
+  'https://bsky.app/profile/pilgrima.ge',
+  'https://www.threads.com/@pilgrima.ge',
+];
+
+export type PageType = 'home' | 'webpage' | 'collection' | 'howto' | 'questionList' | 'app';
+
+export interface Breadcrumb {
+  name: string;
+  url: string;
+}
+
+export interface StructuredDataInput {
+  type: PageType;
+  url: string;
+  title: string;
+  description: string;
+  breadcrumbs?: Breadcrumb[];
+  items?: string[];
+  howToSteps?: string[];
+}
+
+type Node = Record<string, unknown>;
+
+export function organizationNode(): Node {
+  return {
+    '@type': 'Organization',
+    '@id': ORG_ID,
+    name: 'Walk Talk Meditate',
+    url: SITE_URL,
+    logo: LOGO_URL,
+    description: TAGLINE,
+    sameAs: SAME_AS,
+  };
+}
+
+export function websiteNode(): Node {
+  return {
+    '@type': 'WebSite',
+    '@id': WEBSITE_ID,
+    url: SITE_URL,
+    name: 'walk · talk · meditate',
+    description: TAGLINE,
+    inLanguage: 'en',
+    publisher: { '@id': ORG_ID },
+  };
+}
+
+export function buildGraph(input: StructuredDataInput): Record<string, unknown> {
+  const graph: Node[] = [organizationNode(), websiteNode()];
+  return { '@context': 'https://schema.org', '@graph': graph };
+}
+```
+
+- [ ] **Step 7: Run the test to verify it passes**
+
+Run: `npm test`
+Expected: PASS (all tests in `structuredData.test.ts`).
+
+- [ ] **Step 8: Verify the build is still green**
+
+Run: `npm run build`
+Expected: build completes with no errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add package.json package-lock.json vitest.config.ts src/lib/structuredData.ts src/lib/structuredData.test.ts
+git commit -m "feat(seo): add structured-data module with Organization + WebSite nodes"
+```
+
+---
+
+### Task 2: WebPage + BreadcrumbList nodes (webpage & collection types)
+
+**Files:**
+- Modify: `src/lib/structuredData.ts`
+- Test: `src/lib/structuredData.test.ts`
+
+**Interfaces:**
+- Consumes: everything from Task 1.
+- Produces: `breadcrumbNode(url: string, crumbs: Breadcrumb[]): Record<string, unknown>`; `buildGraph` now handles `'webpage'` (→ `WebPage`) and `'collection'` (→ `CollectionPage`), each appending a `BreadcrumbList` when `breadcrumbs` is non-empty.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/lib/structuredData.test.ts`:
+```ts
+import { breadcrumbNode } from './structuredData';
+
+describe('webpage graph', () => {
+  const input = {
+    type: 'webpage' as const,
+    url: 'https://walktalkmeditate.org/guide/planning/',
+    title: 'Planning',
+    description: 'Logistics for solo and group pilgrimages.',
+    breadcrumbs: [
+      { name: 'Home', url: 'https://walktalkmeditate.org/' },
+      { name: 'Guide', url: 'https://walktalkmeditate.org/guide/getting-started/' },
+      { name: 'Planning', url: 'https://walktalkmeditate.org/guide/planning/' },
+    ],
+  };
+
+  it('adds a WebPage that is part of the website and references its breadcrumb', () => {
+    const graph = buildGraph(input) as { '@graph': Array<Record<string, unknown>> };
+    const page = graph['@graph'].find((n) => n['@type'] === 'WebPage')!;
+    expect(page['@id']).toBe('https://walktalkmeditate.org/guide/planning/#webpage');
+    expect(page.isPartOf).toEqual({ '@id': WEBSITE_ID });
+    expect(page.breadcrumb).toEqual({ '@id': 'https://walktalkmeditate.org/guide/planning/#breadcrumb' });
+  });
+
+  it('adds a BreadcrumbList with positioned items', () => {
+    const graph = buildGraph(input) as { '@graph': Array<Record<string, unknown>> };
+    const crumb = graph['@graph'].find((n) => n['@type'] === 'BreadcrumbList')! as {
+      itemListElement: Array<{ position: number; name: string; item: string }>;
+    };
+    expect(crumb.itemListElement).toHaveLength(3);
+    expect(crumb.itemListElement[0]).toMatchObject({ position: 1, name: 'Home' });
+    expect(crumb.itemListElement[2]).toMatchObject({ position: 3, name: 'Planning' });
+  });
+});
+
+describe('collection graph', () => {
+  it('uses CollectionPage as the page type', () => {
+    const graph = buildGraph({
+      type: 'collection',
+      url: 'https://walktalkmeditate.org/questions/',
+      title: 'Questions',
+      description: 'Curated questions for the journey.',
+    }) as { '@graph': Array<Record<string, unknown>> };
+    const types = graph['@graph'].map((n) => n['@type']);
+    expect(types).toContain('CollectionPage');
+    expect(types).not.toContain('WebPage');
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm test`
+Expected: FAIL — `breadcrumbNode` is not exported / no `WebPage` node in graph.
+
+- [ ] **Step 3: Add the WebPage + breadcrumb builders**
+
+In `src/lib/structuredData.ts`, add after `websiteNode()`:
+```ts
+function webPageNode(input: StructuredDataInput, schemaType: string, mainEntityId?: string): Node {
+  const node: Node = {
+    '@type': schemaType,
+    '@id': `${input.url}#webpage`,
+    url: input.url,
+    name: input.title,
+    description: input.description,
+    isPartOf: { '@id': WEBSITE_ID },
+    inLanguage: 'en',
+    primaryImageOfPage: OG_IMAGE,
+  };
+  if (input.breadcrumbs && input.breadcrumbs.length > 0) {
+    node.breadcrumb = { '@id': `${input.url}#breadcrumb` };
+  }
+  if (mainEntityId) {
+    node.mainEntity = { '@id': mainEntityId };
+  }
+  return node;
+}
+
+export function breadcrumbNode(url: string, crumbs: Breadcrumb[]): Node {
+  return {
+    '@type': 'BreadcrumbList',
+    '@id': `${url}#breadcrumb`,
+    itemListElement: crumbs.map((c, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      name: c.name,
+      item: c.url,
+    })),
+  };
+}
+```
+
+- [ ] **Step 4: Extend `buildGraph` to handle webpage & collection**
+
+Replace the body of `buildGraph` with:
+```ts
+export function buildGraph(input: StructuredDataInput): Record<string, unknown> {
+  const graph: Node[] = [organizationNode(), websiteNode()];
+  const crumbs = input.breadcrumbs ?? [];
+  const pushBreadcrumb = () => {
+    if (crumbs.length > 0) graph.push(breadcrumbNode(input.url, crumbs));
+  };
+
+  switch (input.type) {
+    case 'collection':
+      graph.push(webPageNode(input, 'CollectionPage'));
+      pushBreadcrumb();
+      break;
+    case 'webpage':
+    default:
+      graph.push(webPageNode(input, 'WebPage'));
+      pushBreadcrumb();
+      break;
+  }
+
+  return { '@context': 'https://schema.org', '@graph': graph };
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npm test`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/structuredData.ts src/lib/structuredData.test.ts
+git commit -m "feat(seo): add WebPage, CollectionPage, and BreadcrumbList nodes"
+```
+
+---
+
+### Task 3: HowTo, ItemList, MobileApplication + home/app/howto/questionList types
+
+**Files:**
+- Modify: `src/lib/structuredData.ts`
+- Test: `src/lib/structuredData.test.ts`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–2.
+- Produces: `mobileAppNode(): Record<string, unknown>` (exported), `APP_ID` (exported), and `buildGraph` handling `'home'` (WebPage mainEntity=Org + MobileApplication), `'app'` (WebPage mainEntity=App + MobileApplication + breadcrumb), `'howto'` (WebPage + HowTo + breadcrumb), `'questionList'` (CollectionPage + ItemList + breadcrumb).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/lib/structuredData.test.ts`:
+```ts
+import { mobileAppNode, APP_ID } from './structuredData';
+
+describe('mobileAppNode', () => {
+  it('is a free MobileApplication published by the org, pointing at pilgrimapp.org', () => {
+    const app = mobileAppNode();
+    expect(app['@type']).toBe('MobileApplication');
+    expect(app['@id']).toBe(APP_ID);
+    expect(app.url).toBe('https://pilgrimapp.org');
+    expect(app.publisher).toEqual({ '@id': ORG_ID });
+    expect(app.offers).toMatchObject({ price: '0', priceCurrency: 'USD' });
+  });
+});
+
+describe('home graph', () => {
+  it('has a WebPage whose mainEntity is the org, plus the Pilgrim app', () => {
+    const graph = buildGraph({
+      type: 'home',
+      url: 'https://walktalkmeditate.org/',
+      title: 'walk · talk · meditate',
+      description: 'An open-source pilgrimage framework.',
+    }) as { '@graph': Array<Record<string, unknown>> };
+    const page = graph['@graph'].find((n) => n['@type'] === 'WebPage')!;
+    expect(page.mainEntity).toEqual({ '@id': ORG_ID });
+    expect(graph['@graph'].some((n) => n['@type'] === 'MobileApplication')).toBe(true);
+  });
+});
+
+describe('app graph', () => {
+  it("has a WebPage whose mainEntity is the app's @id", () => {
+    const graph = buildGraph({
+      type: 'app',
+      url: 'https://walktalkmeditate.org/pilgrim/',
+      title: 'Pilgrim',
+      description: 'The app for the practice.',
+      breadcrumbs: [
+        { name: 'Home', url: 'https://walktalkmeditate.org/' },
+        { name: 'Pilgrim', url: 'https://walktalkmeditate.org/pilgrim/' },
+      ],
+    }) as { '@graph': Array<Record<string, unknown>> };
+    const page = graph['@graph'].find((n) => n['@type'] === 'WebPage')!;
+    expect(page.mainEntity).toEqual({ '@id': APP_ID });
+    expect(graph['@graph'].some((n) => n['@type'] === 'BreadcrumbList')).toBe(true);
+  });
+});
+
+describe('howto graph', () => {
+  it('adds a HowTo with positioned steps', () => {
+    const graph = buildGraph({
+      type: 'howto',
+      url: 'https://walktalkmeditate.org/guide/getting-started/',
+      title: 'Getting Started',
+      description: 'Your on-ramp to a pilgrimage.',
+      howToSteps: ['Choose a route', 'Pick a question', 'Walk'],
+      breadcrumbs: [{ name: 'Home', url: 'https://walktalkmeditate.org/' }],
+    }) as { '@graph': Array<Record<string, unknown>> };
+    const howto = graph['@graph'].find((n) => n['@type'] === 'HowTo')! as {
+      step: Array<{ position: number; text: string }>;
+    };
+    expect(howto.step).toHaveLength(3);
+    expect(howto.step[0]).toMatchObject({ position: 1, text: 'Choose a route' });
+  });
+});
+
+describe('questionList graph', () => {
+  it('adds an ItemList of the question texts on a CollectionPage', () => {
+    const graph = buildGraph({
+      type: 'questionList',
+      url: 'https://walktalkmeditate.org/questions/morning/',
+      title: 'Morning Seeds',
+      description: 'Prompts for morning meditation.',
+      items: ['What is alive in you?', 'What will you let go of?'],
+    }) as { '@graph': Array<Record<string, unknown>> };
+    const types = graph['@graph'].map((n) => n['@type']);
+    expect(types).toContain('CollectionPage');
+    const list = graph['@graph'].find((n) => n['@type'] === 'ItemList')! as {
+      numberOfItems: number;
+      itemListElement: unknown[];
+    };
+    expect(list.numberOfItems).toBe(2);
+    expect(list.itemListElement).toHaveLength(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm test`
+Expected: FAIL — `mobileAppNode`/`APP_ID` not exported; no HowTo/ItemList/MobileApplication nodes.
+
+- [ ] **Step 3: Add the new node builders**
+
+In `src/lib/structuredData.ts`, add after `breadcrumbNode`:
+```ts
+export const APP_ID = `${SITE_URL}/pilgrim/#app`;
+
+const APP_STORE_URLS: string[] = [
+  'https://apps.apple.com/app/pilgrim-mindful-walking/id6760921056',
+  'https://play.google.com/store/apps/details?id=org.walktalkmeditate.pilgrim',
+];
+
+export function mobileAppNode(): Node {
+  return {
+    '@type': 'MobileApplication',
+    '@id': APP_ID,
+    name: 'Pilgrim',
+    url: 'https://pilgrimapp.org',
+    operatingSystem: 'iOS, Android',
+    applicationCategory: 'HealthApplication',
+    description: 'A privacy-first walking and meditation companion — the app for the walk · talk · meditate practice.',
+    offers: {
+      '@type': 'Offer',
+      price: '0',
+      priceCurrency: 'USD',
+      availability: 'https://schema.org/InStock',
+    },
+    isAccessibleForFree: true,
+    publisher: { '@id': ORG_ID },
+    sameAs: APP_STORE_URLS,
+  };
+}
+
+function howToNode(input: StructuredDataInput): Node {
+  return {
+    '@type': 'HowTo',
+    name: input.title,
+    description: input.description,
+    step: (input.howToSteps ?? []).map((s, i) => ({
+      '@type': 'HowToStep',
+      position: i + 1,
+      text: s,
+    })),
+  };
+}
+
+function itemListNode(input: StructuredDataInput): Node {
+  const items = input.items ?? [];
+  return {
+    '@type': 'ItemList',
+    name: input.title,
+    numberOfItems: items.length,
+    itemListElement: items.map((text, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      name: text,
+    })),
+  };
+}
+```
+
+- [ ] **Step 4: Extend `buildGraph` to handle home/app/howto/questionList**
+
+Replace the `switch` in `buildGraph` with:
+```ts
+  switch (input.type) {
+    case 'home':
+      graph.push(webPageNode(input, 'WebPage', ORG_ID), mobileAppNode());
+      break;
+    case 'app':
+      graph.push(webPageNode(input, 'WebPage', APP_ID), mobileAppNode());
+      pushBreadcrumb();
+      break;
+    case 'howto':
+      graph.push(webPageNode(input, 'WebPage'), howToNode(input));
+      pushBreadcrumb();
+      break;
+    case 'questionList':
+      graph.push(webPageNode(input, 'CollectionPage'), itemListNode(input));
+      pushBreadcrumb();
+      break;
+    case 'collection':
+      graph.push(webPageNode(input, 'CollectionPage'));
+      pushBreadcrumb();
+      break;
+    case 'webpage':
+    default:
+      graph.push(webPageNode(input, 'WebPage'));
+      pushBreadcrumb();
+      break;
+  }
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npm test`
+Expected: PASS (all suites).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/structuredData.ts src/lib/structuredData.test.ts
+git commit -m "feat(seo): add HowTo, ItemList, and MobileApplication graph types"
+```
+
+---
+
+### Task 4: StructuredData component wired into BaseLayout
+
+**Files:**
+- Create: `src/components/StructuredData.astro`
+- Modify: `src/layouts/BaseLayout.astro`
+
+**Interfaces:**
+- Consumes: `buildGraph`, `StructuredDataInput` from `src/lib/structuredData.ts`.
+- Produces: BaseLayout now accepts `structuredData?: Partial<StructuredDataInput>` and renders one `<script type="application/ld+json">` in `<head>`. Default page type is `'webpage'` using the canonical URL, page title, and description.
+
+- [ ] **Step 1: Create the component**
+
+`src/components/StructuredData.astro`:
+```astro
+---
+import { buildGraph, type StructuredDataInput } from '../lib/structuredData';
+
+const graph = buildGraph(Astro.props as StructuredDataInput);
+const json = JSON.stringify(graph).replace(/</g, '\\u003c');
+---
+
+<script type="application/ld+json" is:inline set:html={json} />
+```
+
+- [ ] **Step 2: Import the component and type in BaseLayout**
+
+In `src/layouts/BaseLayout.astro`, add to the frontmatter imports (after the existing imports):
+```astro
+import StructuredData from '../components/StructuredData.astro';
+import type { StructuredDataInput } from '../lib/structuredData';
+```
+
+- [ ] **Step 3: Extend BaseLayout Props and compute the structured-data input**
+
+In `src/layouts/BaseLayout.astro`, change the `Props` interface and add the computed value:
+```astro
+interface Props {
+  title: string;
+  description?: string;
+  structuredData?: Partial<StructuredDataInput>;
+}
+
+const { title, description = 'An open-source pilgrimage framework for walking, talking, and meditating.', structuredData } = Astro.props;
+const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+
+const structuredDataInput: StructuredDataInput = {
+  type: 'webpage',
+  url: canonicalURL.href,
+  title,
+  description,
+  ...structuredData,
+};
+```
+
+- [ ] **Step 4: Render the component in `<head>`**
+
+In `src/layouts/BaseLayout.astro`, add immediately before `<ClientRouter />`:
+```astro
+    <StructuredData {...structuredDataInput} />
+```
+
+- [ ] **Step 5: Build and verify JSON-LD is emitted**
+
+Run:
+```bash
+npm run build && grep -l 'application/ld+json' dist/index.html
+```
+Expected: `dist/index.html` listed; build succeeds.
+
+- [ ] **Step 6: Verify the JSON parses and has a graph**
+
+Run:
+```bash
+node -e "const h=require('fs').readFileSync('dist/index.html','utf8');const m=h.match(/<script type=\"application\/ld\+json\"[^>]*>([\s\S]*?)<\/script>/);const j=JSON.parse(m[1].replace(/\\\\u003c/g,'<'));console.log(j['@graph'].map(n=>n['@type']).join(','));"
+```
+Expected: prints `Organization,WebSite,WebPage` (home still defaults to `webpage` until Task 5).
+
+- [ ] **Step 7: Run unit tests (regression check)**
+
+Run: `npm test`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/StructuredData.astro src/layouts/BaseLayout.astro
+git commit -m "feat(seo): emit JSON-LD on every page via BaseLayout"
+```
+
+---
+
+### Task 5: Page-specific structured data (home, ContentLayout breadcrumbs, questions, how-to)
+
+**Files:**
+- Modify: `src/pages/index.astro`
+- Modify: `src/layouts/ContentLayout.astro`
+- Modify: `src/pages/questions/index.astro`
+- Modify: `src/pages/questions/morning.astro`
+- Modify: `src/pages/questions/evening.astro`
+- Modify: `src/pages/questions/solo.astro`
+- Modify: `src/pages/questions/walking.astro`
+- Modify: `src/pages/guide/getting-started.mdx`
+
+**Interfaces:**
+- Consumes: BaseLayout's `structuredData` prop (Task 4).
+- Produces: each page emits its correct graph type. ContentLayout auto-builds breadcrumbs from `section` + `title` and forwards `structuredData` (including frontmatter `pageType`/`howToSteps` for MDX pages).
+
+- [ ] **Step 1: Set the home page type**
+
+In `src/pages/index.astro`, change the opening tag:
+```astro
+<BaseLayout title="walk · talk · meditate" structuredData={{ type: 'home', description: 'An open-source pilgrimage framework for walking, talking, and meditating — solo or group, local or abroad.' }}>
+```
+
+- [ ] **Step 2: Teach ContentLayout to build breadcrumbs + forward structured data**
+
+In `src/layouts/ContentLayout.astro`, replace the frontmatter with:
+```astro
+---
+import BaseLayout from './BaseLayout.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import Navigation from '../components/Navigation.astro';
+import { SITE_URL, type StructuredDataInput, type PageType, type Breadcrumb } from '../lib/structuredData';
+
+interface Props {
+  title?: string;
+  description?: string;
+  section?: 'guide' | 'ethos' | 'questions';
+  structuredData?: Partial<StructuredDataInput>;
+  frontmatter?: {
+    title?: string;
+    description?: string;
+    section?: 'guide' | 'ethos' | 'questions';
+    pageType?: PageType;
+    howToSteps?: string[];
+  };
+}
+
+const fm = Astro.props.frontmatter;
+const title = Astro.props.title ?? fm?.title ?? '';
+const description = Astro.props.description ?? fm?.description;
+const section = Astro.props.section ?? fm?.section;
+
+const sectionMeta: Record<string, Breadcrumb> = {
+  guide: { name: 'Guide', url: `${SITE_URL}/guide/getting-started/` },
+  ethos: { name: 'Ethos', url: `${SITE_URL}/ethos/open-source/` },
+  questions: { name: 'Questions', url: `${SITE_URL}/questions/` },
+};
+
+const currentUrl = new URL(Astro.url.pathname, Astro.site).href;
+const breadcrumbs: Breadcrumb[] = [{ name: 'Home', url: `${SITE_URL}/` }];
+if (section && sectionMeta[section]) {
+  breadcrumbs.push(sectionMeta[section]);
+  if (sectionMeta[section].url !== currentUrl) {
+    breadcrumbs.push({ name: title, url: currentUrl });
+  }
+}
+
+const structuredData: Partial<StructuredDataInput> = {
+  type: fm?.pageType ?? 'webpage',
+  title,
+  description,
+  breadcrumbs,
+  ...(fm?.howToSteps ? { howToSteps: fm.howToSteps } : {}),
+  ...Astro.props.structuredData,
+};
+---
+```
+
+- [ ] **Step 3: Pass structured data from ContentLayout to BaseLayout**
+
+In `src/layouts/ContentLayout.astro`, change the `<BaseLayout …>` opening tag:
+```astro
+<BaseLayout title={`${title} — walk · talk · meditate`} description={description} structuredData={structuredData}>
+```
+
+- [ ] **Step 4: Set the questions index to a collection**
+
+In `src/pages/questions/index.astro`, change the `<ContentLayout …>` opening tag:
+```astro
+<ContentLayout title="Questions" section="questions" description="Curated questions for walking, talking, and reflecting on pilgrimage." structuredData={{ type: 'collection' }}>
+```
+
+- [ ] **Step 5: Add ItemList to each question sub-page**
+
+In `src/pages/questions/morning.astro`, change the `<ContentLayout …>` opening tag to pass the question texts:
+```astro
+<ContentLayout title="Morning Seeds" section="questions" description="One-sentence contemplative prompts for morning meditation." structuredData={{ type: 'questionList', items: questions.map((q) => q.text) }}>
+```
+
+Repeat the identical pattern (only `title`, `description`, and the existing `questions` variable are reused) for the other three, keeping their current titles/descriptions:
+- `src/pages/questions/evening.astro`
+- `src/pages/questions/solo.astro`
+- `src/pages/questions/walking.astro`
+
+Each already loads `const { description, questions } = entry!.data;`, so add `structuredData={{ type: 'questionList', items: questions.map((q) => q.text) }}` to its `<ContentLayout>` tag.
+
+- [ ] **Step 6: Make getting-started a HowTo**
+
+In `src/pages/guide/getting-started.mdx`, replace the frontmatter block with:
+```yaml
+---
+layout: ../../layouts/ContentLayout.astro
+title: Getting Started
+description: Your on-ramp to a pilgrimage — solo or group, local or abroad.
+section: guide
+pageType: howto
+howToSteps:
+  - Choose a route — 2–3 hours of walking, ideally on paths rather than roads
+  - Pick a question — choose one from the morning seeds to carry with you
+  - Walk — at a comfortable pace, present with each step
+  - Reflect — voice-record or journal after your walk
+  - Sit — close with 10–30 minutes of meditation
+---
+```
+
+- [ ] **Step 7: Build and verify each page type**
+
+Run:
+```bash
+npm run build
+node -e "const fs=require('fs');const grab=p=>{const h=fs.readFileSync(p,'utf8');const m=h.match(/<script type=\"application\/ld\+json\"[^>]*>([\s\S]*?)<\/script>/);return JSON.parse(m[1].replace(/\\\\u003c/g,'<'))['@graph'].map(n=>n['@type']).join(',');};console.log('home:',grab('dist/index.html'));console.log('getting-started:',grab('dist/guide/getting-started/index.html'));console.log('questions/morning:',grab('dist/questions/morning/index.html'));console.log('questions index:',grab('dist/questions/index.html'));console.log('ethos:',grab('dist/ethos/open-source/index.html'));"
+```
+Expected:
+- `home: Organization,WebSite,WebPage,MobileApplication`
+- `getting-started: Organization,WebSite,WebPage,HowTo,BreadcrumbList`
+- `questions/morning: Organization,WebSite,CollectionPage,ItemList,BreadcrumbList`
+- `questions index: Organization,WebSite,CollectionPage,BreadcrumbList`
+- `ethos: Organization,WebSite,WebPage,BreadcrumbList`
+
+- [ ] **Step 8: Run unit tests + astro check**
+
+Run: `npm test && npx astro check`
+Expected: tests PASS; astro check reports no errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/pages/index.astro src/layouts/ContentLayout.astro src/pages/questions/ src/pages/guide/getting-started.mdx
+git commit -m "feat(seo): wire per-page JSON-LD types (home, how-to, question lists, breadcrumbs)"
+```
+
+---
+
+### Task 6: `/pilgrim/` bridge page + home teaser + family footer
+
+**Files:**
+- Create: `src/pages/pilgrim.astro`
+- Modify: `src/pages/index.astro`
+- Modify: `src/components/Footer.astro`
+
+**Interfaces:**
+- Consumes: ContentLayout `structuredData` passthrough (Task 5); `type: 'app'`.
+- Produces: `/pilgrim/` page carrying `MobileApplication` JSON-LD; a home teaser linking to it; footer family links.
+
+- [ ] **Step 1: Create the bridge page**
+
+`src/pages/pilgrim.astro`:
+```astro
+---
+import ContentLayout from '../layouts/ContentLayout.astro';
+import { SITE_URL } from '../lib/structuredData';
+
+const breadcrumbs = [
+  { name: 'Home', url: `${SITE_URL}/` },
+  { name: 'Pilgrim', url: `${SITE_URL}/pilgrim/` },
+];
+---
+
+<ContentLayout
+  title="Pilgrim"
+  description="The companion app for the walk · talk · meditate practice — privacy-first, open source, free forever."
+  structuredData={{ type: 'app', breadcrumbs }}
+>
+  <p>
+    walk · talk · meditate is the practice. <strong>Pilgrim</strong> is the tool you
+    carry on the path — a quiet, privacy-first companion for iPhone and Android. No
+    accounts, no analytics, no cloud. Open source, free forever.
+  </p>
+
+  <h2>The three pillars, in your pocket</h2>
+  <ul>
+    <li><strong>Walk</strong> — GPS route tracking and voice notes transcribed on-device, so a thought mid-walk is never lost.</li>
+    <li><strong>Talk</strong> — reflection prompts generated from your own voice notes and photos, alongside the curated <a href="/questions/">65 questions</a>.</li>
+    <li><strong>Meditate</strong> — a walking-meditation breathing circle with ambient soundscapes and seven voice guides.</li>
+  </ul>
+
+  <p>
+    Everything stays on your phone. Voice transcription runs entirely on-device. The
+    full source is on <a href="https://github.com/walktalkmeditate/pilgrim-ios">GitHub</a>.
+  </p>
+
+  <div class="mt-10 flex flex-wrap gap-4 not-prose">
+    <a
+      href="https://apps.apple.com/app/pilgrim-mindful-walking/id6760921056"
+      class="inline-flex items-center font-ui text-sm px-5 py-3 rounded-lg bg-sand-800 text-sand-50 dark:bg-dusk-100 dark:text-dusk-900 hover:opacity-80 transition-opacity"
+    >
+      Download for iOS
+    </a>
+    <a
+      href="https://play.google.com/store/apps/details?id=org.walktalkmeditate.pilgrim"
+      class="inline-flex items-center font-ui text-sm px-5 py-3 rounded-lg border border-sand-300 text-sand-700 dark:border-dusk-700 dark:text-dusk-200 hover:border-sand-500 transition-colors"
+    >
+      Download for Android
+    </a>
+  </div>
+
+  <p class="mt-8 font-ui text-sm text-sand-400 dark:text-dusk-300 not-prose">
+    Full details and the contemplative-instrument almanac live at
+    <a href="https://pilgrimapp.org" class="underline hover:text-sand-600 dark:hover:text-dusk-200">pilgrimapp.org</a>.
+  </p>
+</ContentLayout>
+```
+
+- [ ] **Step 2: Add the home teaser section**
+
+In `src/pages/index.astro`, add this section immediately before the closing `</main>` (after the "Join the community" section and its divider — add a divider first):
+```astro
+    <div class="border-t border-sand-200 dark:border-dusk-800" />
+
+    <section class="py-20 md:py-28 reveal">
+      <a
+        href={`${base}pilgrim/`}
+        class="group inline-flex items-center gap-3 font-heading text-2xl md:text-3xl font-light text-sand-800 dark:text-dusk-100 hover:text-sage dark:hover:text-sage-light transition-colors tracking-display"
+      >
+        Carry the practice with Pilgrim
+        <span class="text-sand-300 dark:text-dusk-700 group-hover:text-sage dark:group-hover:text-sage-light group-hover:translate-x-1 transition-all">→</span>
+      </a>
+      <p class="mt-4 text-sand-400 dark:text-dusk-300 font-ui text-sm">
+        The companion app. Privacy-first, open source, free forever.
+      </p>
+    </section>
+```
+
+- [ ] **Step 3: Add family links to the footer**
+
+In `src/components/Footer.astro`, replace the `<span>walk · talk · meditate</span>` line with a family link group:
+```astro
+      <div class="flex flex-wrap gap-x-5 gap-y-1 items-center">
+        <span>walk · talk · meditate</span>
+        <a href="https://pilgrimapp.org" class="hover:text-sand-600 dark:hover:text-dusk-200 transition-colors">Pilgrim</a>
+        <a href="https://github.com/walktalkmeditate/open-pilgrimages" class="hover:text-sand-600 dark:hover:text-dusk-200 transition-colors">open-pilgrimages</a>
+      </div>
+```
+
+- [ ] **Step 4: Build and verify the /pilgrim/ graph**
+
+Run:
+```bash
+npm run build
+node -e "const fs=require('fs');const h=fs.readFileSync('dist/pilgrim/index.html','utf8');const m=h.match(/<script type=\"application\/ld\+json\"[^>]*>([\s\S]*?)<\/script>/);const g=JSON.parse(m[1].replace(/\\\\u003c/g,'<'))['@graph'];console.log(g.map(n=>n['@type']).join(','));const app=g.find(n=>n['@type']==='MobileApplication');console.log('app.mainEntity-linked:',g.find(n=>n['@type']==='WebPage').mainEntity['@id']===app['@id']);"
+```
+Expected: `Organization,WebSite,WebPage,MobileApplication,BreadcrumbList` and `app.mainEntity-linked: true`.
+
+- [ ] **Step 5: Confirm the home teaser link and footer family render**
+
+Run:
+```bash
+grep -c 'pilgrim/' dist/index.html && grep -c 'pilgrimapp.org' dist/index.html
+```
+Expected: both ≥ 1.
+
+- [ ] **Step 6: Run unit tests + astro check**
+
+Run: `npm test && npx astro check`
+Expected: tests PASS; astro check no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/pages/pilgrim.astro src/pages/index.astro src/components/Footer.astro
+git commit -m "feat: add Pilgrim companion-app bridge page, home teaser, and family footer"
+```
+
+---
+
+### Task 7: `llms.txt` and `robots.txt`
+
+**Files:**
+- Create: `public/llms.txt`
+- Create: `public/robots.txt`
+
+**Interfaces:**
+- None (static files copied to site root by Astro).
+
+- [ ] **Step 1: Create `public/robots.txt`**
+
+```
+User-agent: *
+Allow: /
+
+Sitemap: https://walktalkmeditate.org/sitemap-index.xml
+```
+
+- [ ] **Step 2: Create `public/llms.txt`**
+
+```
+# walk · talk · meditate — An open-source pilgrimage framework
+
+> walk · talk · meditate is an open-source framework for pilgrimage as
+> practice. Three equal pillars — walking as practice (not transit), deep
+> conversation (not small talk), and meditation — turn any walk, solo or
+> group, local or abroad, into a pilgrimage. No gear required. Start
+> tomorrow in your own town.
+
+## What it is
+
+A philosophy and a practical guide, not a product. Inspired by the
+walk-and-talk tradition, with meditation added as an equal third pillar.
+The motto: slow and chill. The practice: relax and release. The way:
+peace and harmony.
+
+## The three pillars
+
+- Walk — walking as practice, side by side, step by step.
+- Talk — deep reflection and connection; 65 curated questions for the journey.
+- Meditate — seeking the peace and calmness within.
+
+## Sections
+
+- Guide — getting started, planning, preparing, on the journey, coming home:
+  https://walktalkmeditate.org/guide/getting-started/
+- Questions — 65 curated prompts by context (walking, evening, solo, morning):
+  https://walktalkmeditate.org/questions/
+- Ethos — open source, the golden rule, radical presence:
+  https://walktalkmeditate.org/ethos/open-source/
+
+## Companion app
+
+Pilgrim is the app for this practice — a privacy-first walking and
+meditation companion for iOS and Android. No accounts, no analytics, no
+cloud; voice notes transcribed on-device; open source (GPLv3), free forever.
+
+- App + bridge page: https://walktalkmeditate.org/pilgrim/
+- Full app site: https://pilgrimapp.org
+
+## Related
+
+- GitHub org: https://github.com/walktalkmeditate
+- Open pilgrimage routes dataset: https://github.com/walktalkmeditate/open-pilgrimages
+- Community discussions: https://github.com/orgs/walktalkmeditate/discussions
+
+## License
+
+Content and code: open source. See the repository for details.
+```
+
+- [ ] **Step 3: Build and verify both files reach the site root**
+
+Run:
+```bash
+npm run build && ls dist/llms.txt dist/robots.txt
+```
+Expected: both files listed under `dist/`.
+
+- [ ] **Step 4: Confirm the sitemap target exists**
+
+Run: `ls dist/sitemap-index.xml`
+Expected: file exists (so `robots.txt`'s `Sitemap:` line is valid).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add public/llms.txt public/robots.txt
+git commit -m "feat(seo): add llms.txt and robots.txt"
+```
+
+---
+
+## Final verification
+
+- [ ] `npm test` — all structured-data unit tests pass.
+- [ ] `npm run build && npx astro check` — clean build, no type errors.
+- [ ] Spot-check one page's JSON-LD in [Google Rich Results Test](https://search.google.com/test/rich-results) (paste the rendered HTML) — Organization, WebSite, BreadcrumbList, HowTo all recognized.
+- [ ] `git status` shows **no** changes under `../pilgrim-landing`.
+
+## Self-review notes (author)
+
+- **Spec coverage:** Part 1 JSON-LD → Tasks 1–6; `llms.txt`/`robots.txt` → Task 7; `/pilgrim/` + home teaser → Task 6; family footer → Task 6; Organization `sameAs` unification → Task 1. All "Now" tier items covered. "Next"/"Later" tier items (question-of-the-day, contextual guide deep links, contribute surface, printable guide, per-section OG, shareable cards) are intentionally **out of scope** for this plan.
+- **Type consistency:** `buildGraph`, `StructuredDataInput`, `breadcrumbNode`, `mobileAppNode`, `APP_ID`, `ORG_ID`, `WEBSITE_ID`, `SITE_URL` names are used identically across tasks.
+- **No placeholders:** every code step shows complete code; every run step shows the expected output.

--- a/docs/superpowers/specs/2026-06-21-json-ld-and-pilgrim-ecosystem-design.md
+++ b/docs/superpowers/specs/2026-06-21-json-ld-and-pilgrim-ecosystem-design.md
@@ -1,0 +1,199 @@
+# JSON-LD, Site Polish & Pilgrim Ecosystem — Design
+
+**Date:** 2026-06-21
+**Status:** Draft (awaiting review)
+**Site:** walktalkmeditate.org (Astro + Tailwind, GitHub Pages)
+
+## Context
+
+walktalkmeditate.org is the *framework / philosophy* — three pillars (walk · talk ·
+meditate), a pilgrimage guide, an ethos section, and 65 curated questions. Pilgrim
+(pilgrimapp.org, `../pilgrim-landing`) is the *app* — a privacy-first walking
+companion. Both ship under the same `walktalkmeditate` GitHub org. Pilgrim's site
+already declares the shared `Organization` ("Walk Talk Meditate", `url:
+https://walktalkmeditate.org`) in its JSON-LD. walktalkmeditate has **no structured
+data yet** and has not claimed its own canonical Organization node.
+
+The guiding narrative for the ecosystem: **walktalkmeditate is the *why / how*;
+Pilgrim is the *tool on the path*.**
+
+## Goals
+
+1. Add a coherent JSON-LD `@graph` to every page, following the graph + shared-`@id`
+   model from [Hawksley's JSON-LD guide](https://hawksley.dev/blog/json-ld-explained-for-personal-websites/).
+2. Improve discoverability (AI citation + search) with `llms.txt`, `robots.txt`, and
+   meta hygiene.
+3. Add on-theme contemplative craft (question-of-the-day, printable guide).
+4. Tie Pilgrim into the family as a first-class companion, **walktalkmeditate-side only**.
+
+## Non-Goals
+
+- **No edits to `../pilgrim-landing`.** All Pilgrim linking is one-directional
+  (walktalkmeditate → pilgrimapp.org). Pilgrim already names walktalkmeditate.org as
+  the org URL, so the identity link exists one way; we will not change Pilgrim's graph.
+- No named-individual identity. Publisher is the **Organization** ("Walk Talk Meditate").
+- No blog / RSS now (no evolving content stream exists — YAGNI).
+- No new interactive "almanac" instruments (sunpath/daylight-style). Question-of-the-day
+  is the one small interactive element, justified as contemplative craft.
+- No re-selling the app on walktalkmeditate; `/pilgrim/` is a bridge, not a clone.
+
+---
+
+## Part 1 — JSON-LD
+
+### Architecture
+
+A single `src/components/StructuredData.astro` component builds a schema.org `@graph`
+and emits **one** `<script type="application/ld+json" is:inline>`. It is rendered from
+`BaseLayout.astro` so every page is covered. Driven by props:
+
+```ts
+interface Props {
+  type: 'home' | 'webpage' | 'collection' | 'howto' | 'questionList' | 'app';
+  title: string;
+  description: string;
+  breadcrumbs?: { name: string; url: string }[]; // omitted on home
+  items?: string[];        // for questionList: the question texts
+  howToSteps?: string[];   // for howto: ordered step text
+}
+```
+
+Rejected alternative: inline JSON-LD per page (duplication + drift — the exact problem
+visible in pilgrim-landing's hand-maintained blocks).
+
+### Persistent nodes (emitted on every page)
+
+- **`Organization`** — `@id: https://walktalkmeditate.org/#organization`
+  - `name: "Walk Talk Meditate"`, `url`, `logo` (logo-128.png), `description`
+  - `sameAs`: `https://pilgrimapp.org`, GitHub org, App Store, Play Store, Mastodon
+    (`@pilgrimage`), Bluesky (`pilgrima.ge`), Threads (`@pilgrima.ge`) — the array
+    Pilgrim already uses, **plus pilgrimapp.org**. This fuses both sites into one
+    identity for crawlers.
+- **`WebSite`** — `@id: https://walktalkmeditate.org/#website`
+  - `name: "walk · talk · meditate"`, `url`, `description`, `inLanguage: "en"`,
+    `publisher` → `#organization`.
+
+### Per-page nodes
+
+| Page(s) | Page node | Extra node |
+|---|---|---|
+| `/` (home) | `WebPage` (`mainEntity` → `#organization`) | `MobileApplication` (Pilgrim bridge) |
+| `/pilgrim/` | `WebPage` (`mainEntity` → the app) | `MobileApplication` (Pilgrim) + `BreadcrumbList` |
+| `/guide/getting-started/` | `WebPage` | `HowTo` + `BreadcrumbList` |
+| `/guide/*` (others) | `WebPage` | `BreadcrumbList` |
+| `/ethos/*` | `WebPage` | `BreadcrumbList` |
+| `/questions/` | `CollectionPage` | `BreadcrumbList` |
+| `/questions/{walking,evening,solo,morning}/` | `CollectionPage` | `ItemList` (questions) + `BreadcrumbList` |
+
+- Every non-home page carries a **`BreadcrumbList`** (`@id: {url}#breadcrumb`), e.g.
+  *Home › Guide › Getting Started* — per the blog post's recommendation.
+- Every page node uses `@id: {url}#webpage`, `isPartOf` → `#website`, `breadcrumb` →
+  `#breadcrumb`, `inLanguage: "en"`, `primaryImageOfPage` → og.png.
+- **`HowTo`** (`getting-started`) models the literal numbered "Minimum Viable
+  Pilgrimage" steps → eligible for how-to rich results.
+- **`ItemList`** lists each page's question texts (`itemListElement` of `ListItem`).
+- **`MobileApplication`** (Pilgrim bridge): `name: "Pilgrim"`, `url:
+  https://pilgrimapp.org`, `operatingSystem`, `applicationCategory:
+  "HealthApplication"`, `offers` { price 0, USD, InStock }, `isAccessibleForFree:
+  true`, `publisher` → `#organization`, `sameAs` store URLs. Declares from
+  walktalkmeditate's own graph that this org makes this app.
+
+### Example — home page graph (abridged)
+
+```json
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    { "@type": "Organization", "@id": "https://walktalkmeditate.org/#organization",
+      "name": "Walk Talk Meditate", "url": "https://walktalkmeditate.org",
+      "logo": "https://walktalkmeditate.org/logo-128.png",
+      "sameAs": ["https://pilgrimapp.org", "https://github.com/walktalkmeditate", "..."] },
+    { "@type": "WebSite", "@id": "https://walktalkmeditate.org/#website",
+      "url": "https://walktalkmeditate.org", "name": "walk · talk · meditate",
+      "inLanguage": "en", "publisher": { "@id": "https://walktalkmeditate.org/#organization" } },
+    { "@type": "WebPage", "@id": "https://walktalkmeditate.org/#webpage",
+      "url": "https://walktalkmeditate.org", "isPartOf": { "@id": "https://walktalkmeditate.org/#website" },
+      "mainEntity": { "@id": "https://walktalkmeditate.org/#organization" } },
+    { "@type": "MobileApplication", "name": "Pilgrim", "url": "https://pilgrimapp.org",
+      "operatingSystem": "iOS, Android", "applicationCategory": "HealthApplication",
+      "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+      "publisher": { "@id": "https://walktalkmeditate.org/#organization" } }
+  ]
+}
+```
+
+### Validation
+
+- Build passes (`npm run build`, `astro check`).
+- Each page type validated in Google Rich Results Test + schema.org validator.
+- View-transition safe: emitted in `<head>` via `is:inline` so it persists across
+  Astro client routing.
+
+---
+
+## Part 2 — Site polish
+
+### Discoverability
+- **`public/llms.txt`** — framework overview (pillars, guide, questions) + Pilgrim as
+  companion app, modeled on pilgrim-landing's llms.txt.
+- **`public/robots.txt`** — allow all, point to `sitemap-index.xml`.
+- Audit every page's `description` meta for quality/uniqueness.
+
+### Contemplative craft
+- **Question of the day** — a date-deterministic draw from the 65 questions, surfaced
+  on the home page (and/or `/questions/`). Deterministic by date so "today's question"
+  is shareable and stable. Pure build-time or tiny inline JS; no dependency.
+- **Printable guide** — a print stylesheet so the guide prints as a clean booklet to
+  carry. On-brand with "no gear required."
+
+### Community & growth
+- A **"Contribute / adapt this"** surface (page or section) making the README's
+  fork-it invitation visible: contribute questions, routes, run your own pilgrimage.
+- Strengthen the home "organize a walk / join the community" CTA.
+
+---
+
+## Part 3 — Pilgrim integration (walktalkmeditate-side only)
+
+1. **Structured-data identity** — Organization `sameAs` includes pilgrimapp.org (Part 1).
+2. **`/pilgrim/` bridge page** — one screen: a bridge paragraph mapping pillars →
+   app capabilities (walk → GPS + voice notes; talk → reflection prompts + the 65
+   questions; meditate → breathing circle), one privacy/open-source line, App Store +
+   Play buttons, "full details → pilgrimapp.org". Carries `MobileApplication` JSON-LD.
+   **Not** a clone of pilgrimapp.org.
+3. **Home teaser** — a short section inviting people to the companion app, linking to
+   `/pilgrim/`.
+4. **Contextual deep links in the guide** — at the moments the app helps: getting-started
+   step 4 ("voice-record or journal") → `/pilgrim/`; meditation mentions → Pilgrim's
+   walking-meditation mode; questions → Pilgrim's reflection prompts. Natural, sparse.
+5. **Family footer strip** — add Pilgrim + open-pilgrimages + GitHub org to the footer
+   so either entry point reveals the whole family.
+
+---
+
+## Priority tiers
+
+- **Now:** Part 1 (all JSON-LD), `llms.txt`, `robots.txt`, `/pilgrim/` page + home
+  teaser, family footer, Organization `sameAs` unification.
+- **Next:** Question of the day, contextual guide deep links, contribute surface,
+  description-meta audit.
+- **Later:** printable guide stylesheet, shareable per-question cards, per-section OG
+  images.
+
+## Acceptance criteria
+
+- [ ] Every page emits exactly one valid JSON-LD `@graph`; passes Rich Results Test.
+- [ ] Organization + WebSite nodes share stable `@id`s across all pages.
+- [ ] Non-home pages carry a correct BreadcrumbList; getting-started carries a HowTo;
+      question pages carry an ItemList.
+- [ ] `llms.txt` and `robots.txt` served at site root.
+- [ ] `/pilgrim/` page exists, links to stores + pilgrimapp.org, carries
+      MobileApplication JSON-LD; home teaser links to it.
+- [ ] Footer shows the family (Pilgrim, open-pilgrimages, GitHub org).
+- [ ] `npm run build` + `astro check` clean; JSON-LD survives view transitions.
+- [ ] No files in `../pilgrim-landing` changed.
+
+## Open questions
+
+- Newsletter / "now" page — defer? (Pilgrim has one; not required for this work.)
+- `/pilgrim/` URL slug: `/pilgrim/` vs `/app/` — recommend `/pilgrim/`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,9 @@
         "@astrojs/tailwind": "^6.0.2",
         "astro": "^5.18.0",
         "tailwindcss": "^3.4.17"
+      },
+      "devDependencies": {
+        "vitest": "^3.2.6"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1758,6 +1761,17 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -1766,6 +1780,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1850,6 +1871,121 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.6",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/@volar/kit": {
       "version": "2.4.28",
@@ -2128,6 +2264,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/astring": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
@@ -2381,6 +2527,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/camelcase": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
@@ -2430,6 +2586,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -2482,6 +2655,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -2817,6 +3000,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/defu": {
@@ -3214,6 +3407,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -3901,6 +4104,13 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -3967,6 +4177,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "11.2.6",
@@ -5357,6 +5574,23 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/piccolore": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
@@ -6178,6 +6412,13 @@
         "@types/hast": "^3.0.4"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -6249,6 +6490,20 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stream-replace-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
@@ -6299,6 +6554,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/style-to-js": {
@@ -6511,6 +6779,13 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -6534,6 +6809,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -7108,6 +7413,29 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
@@ -7584,6 +7912,86 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/volar-service-css": {
       "version": "0.0.68",
       "resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.68.tgz",
@@ -7838,6 +8246,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/widest-line": {

--- a/package.json
+++ b/package.json
@@ -6,14 +6,19 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
-    "astro": "^5.18.0",
+    "@astrojs/check": "^0.9.4",
     "@astrojs/mdx": "^4.3.0",
     "@astrojs/sitemap": "^3.3.1",
     "@astrojs/tailwind": "^6.0.2",
-    "tailwindcss": "^3.4.17",
-    "@astrojs/check": "^0.9.4"
+    "astro": "^5.18.0",
+    "tailwindcss": "^3.4.17"
+  },
+  "devDependencies": {
+    "vitest": "^3.2.6"
   }
 }

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,48 @@
+# walk · talk · meditate — An open-source pilgrimage framework
+
+> walk · talk · meditate is an open-source framework for pilgrimage as
+> practice. Three equal pillars — walking as practice (not transit), deep
+> conversation (not small talk), and meditation — turn any walk, solo or
+> group, local or abroad, into a pilgrimage. No gear required. Start
+> tomorrow in your own town.
+
+## What it is
+
+A philosophy and a practical guide, not a product. Inspired by the
+walk-and-talk tradition, with meditation added as an equal third pillar.
+The motto: slow and chill. The practice: relax and release. The way:
+peace and harmony.
+
+## The three pillars
+
+- Walk — walking as practice, side by side, step by step.
+- Talk — deep reflection and connection; 65 curated questions for the journey.
+- Meditate — seeking the peace and calmness within.
+
+## Sections
+
+- Guide — getting started, planning, preparing, on the journey, coming home:
+  https://walktalkmeditate.org/guide/getting-started/
+- Questions — 65 curated prompts by context (walking, evening, solo, morning):
+  https://walktalkmeditate.org/questions/
+- Ethos — open source, the golden rule, radical presence:
+  https://walktalkmeditate.org/ethos/open-source/
+
+## Companion app
+
+Pilgrim is the app for this practice — a privacy-first walking and
+meditation companion for iOS and Android. No accounts, no analytics, no
+cloud; voice notes transcribed on-device; open source (GPLv3), free forever.
+
+- App + bridge page: https://walktalkmeditate.org/pilgrim/
+- Full app site: https://pilgrimapp.org
+
+## Related
+
+- GitHub org: https://github.com/walktalkmeditate
+- Open pilgrimage routes dataset: https://github.com/walktalkmeditate/open-pilgrimages
+- Community discussions: https://github.com/orgs/walktalkmeditate/discussions
+
+## License
+
+Content and code: open source. See the repository for details.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -21,6 +21,8 @@ peace and harmony.
 
 ## Sections
 
+- Pillars — the three practices, each with its own page:
+  https://walktalkmeditate.org/walk/ · https://walktalkmeditate.org/talk/ · https://walktalkmeditate.org/meditate/
 - Guide — getting started, planning, preparing, on the journey, coming home:
   https://walktalkmeditate.org/guide/getting-started/
 - Questions — 65 curated prompts by context (walking, evening, solo, morning):

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://walktalkmeditate.org/sitemap-index.xml

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -5,7 +5,11 @@ const base = import.meta.env.BASE_URL;
 <footer class="mt-32 mb-16">
   <div class="max-w-wide mx-auto px-6">
     <div class="border-t border-sand-200 dark:border-dusk-800 pt-8 font-ui text-xs text-sand-400 dark:text-dusk-300 flex justify-between items-center">
-      <span>walk · talk · meditate</span>
+      <div class="flex flex-wrap gap-x-5 gap-y-1 items-center">
+        <span>walk · talk · meditate</span>
+        <a href="https://pilgrimapp.org" class="hover:text-sand-600 dark:hover:text-dusk-200 transition-colors">Pilgrim</a>
+        <a href="https://github.com/walktalkmeditate/open-pilgrimages" class="hover:text-sand-600 dark:hover:text-dusk-200 transition-colors">open-pilgrimages</a>
+      </div>
       <div class="flex gap-5 items-center">
         <a href={`${base}ethos/open-source/`} class="hover:text-sand-600 dark:hover:text-dusk-200 transition-colors" aria-label="Open source ethos">
           <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">

--- a/src/components/StructuredData.astro
+++ b/src/components/StructuredData.astro
@@ -1,7 +1,7 @@
 ---
-import { buildGraph, type StructuredDataInput } from '../lib/structuredData';
+import { buildGraph, type StructuredDataInput } from '../lib/structured-data';
 
-interface Props extends StructuredDataInput {}
+type Props = StructuredDataInput;
 
 const graph = buildGraph(Astro.props);
 const json = JSON.stringify(graph).replace(/</g, '\\u003c');

--- a/src/components/StructuredData.astro
+++ b/src/components/StructuredData.astro
@@ -1,0 +1,8 @@
+---
+import { buildGraph, type StructuredDataInput } from '../lib/structuredData';
+
+const graph = buildGraph(Astro.props as StructuredDataInput);
+const json = JSON.stringify(graph).replace(/</g, '\\u003c');
+---
+
+<script type="application/ld+json" is:inline set:html={json} />

--- a/src/components/StructuredData.astro
+++ b/src/components/StructuredData.astro
@@ -1,7 +1,9 @@
 ---
 import { buildGraph, type StructuredDataInput } from '../lib/structuredData';
 
-const graph = buildGraph(Astro.props as StructuredDataInput);
+interface Props extends StructuredDataInput {}
+
+const graph = buildGraph(Astro.props);
 const json = JSON.stringify(graph).replace(/</g, '\\u003c');
 ---
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -3,14 +3,25 @@ import { ClientRouter } from 'astro:transitions';
 import '../styles/global.css';
 import Particles from '../components/Particles.astro';
 import ThemeToggle from '../components/ThemeToggle.astro';
+import StructuredData from '../components/StructuredData.astro';
+import type { StructuredDataInput } from '../lib/structuredData';
 
 interface Props {
   title: string;
   description?: string;
+  structuredData?: Partial<StructuredDataInput>;
 }
 
-const { title, description = 'An open-source pilgrimage framework for walking, talking, and meditating.' } = Astro.props;
+const { title, description = 'An open-source pilgrimage framework for walking, talking, and meditating.', structuredData } = Astro.props;
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+
+const structuredDataInput: StructuredDataInput = {
+  type: 'webpage',
+  url: canonicalURL.href,
+  title,
+  description,
+  ...structuredData,
+};
 ---
 
 <!doctype html>
@@ -42,6 +53,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
     />
 
     <script defer src="https://analytics.walktalkmeditate.org/script.js" data-website-id="507df3e8-800c-4b96-aa36-14805b24b5ed" is:inline></script>
+    <StructuredData {...structuredDataInput} />
     <ClientRouter />
     <title>{title}</title>
     <script is:inline>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -4,7 +4,7 @@ import '../styles/global.css';
 import Particles from '../components/Particles.astro';
 import ThemeToggle from '../components/ThemeToggle.astro';
 import StructuredData from '../components/StructuredData.astro';
-import type { StructuredDataInput } from '../lib/structuredData';
+import { TAGLINE, type StructuredDataInput } from '../lib/structured-data';
 
 interface Props {
   title: string;
@@ -12,7 +12,7 @@ interface Props {
   structuredData?: Partial<StructuredDataInput>;
 }
 
-const { title, description = 'An open-source pilgrimage framework for walking, talking, and meditating.', structuredData } = Astro.props;
+const { title, description = TAGLINE, structuredData } = Astro.props;
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
 const structuredDataInput: StructuredDataInput = {

--- a/src/layouts/ContentLayout.astro
+++ b/src/layouts/ContentLayout.astro
@@ -3,7 +3,7 @@ import BaseLayout from './BaseLayout.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import Navigation from '../components/Navigation.astro';
-import { SITE_URL, type StructuredDataInput, type PageType, type Breadcrumb } from '../lib/structuredData';
+import { SITE_URL, type StructuredDataInput, type PageType, type Breadcrumb } from '../lib/structured-data';
 
 interface Props {
   title?: string;
@@ -37,6 +37,8 @@ if (section && sectionMeta[section]) {
   if (sectionMeta[section].url !== currentUrl) {
     breadcrumbs.push({ name: title, url: currentUrl });
   }
+} else if (title) {
+  breadcrumbs.push({ name: title, url: currentUrl });
 }
 
 const structuredData: Partial<StructuredDataInput> = {

--- a/src/layouts/ContentLayout.astro
+++ b/src/layouts/ContentLayout.astro
@@ -3,15 +3,19 @@ import BaseLayout from './BaseLayout.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import Navigation from '../components/Navigation.astro';
+import { SITE_URL, type StructuredDataInput, type PageType, type Breadcrumb } from '../lib/structuredData';
 
 interface Props {
   title?: string;
   description?: string;
   section?: 'guide' | 'ethos' | 'questions';
+  structuredData?: Partial<StructuredDataInput>;
   frontmatter?: {
     title?: string;
     description?: string;
     section?: 'guide' | 'ethos' | 'questions';
+    pageType?: PageType;
+    howToSteps?: string[];
   };
 }
 
@@ -19,9 +23,33 @@ const fm = Astro.props.frontmatter;
 const title = Astro.props.title ?? fm?.title ?? '';
 const description = Astro.props.description ?? fm?.description;
 const section = Astro.props.section ?? fm?.section;
+
+const sectionMeta: Record<string, Breadcrumb> = {
+  guide: { name: 'Guide', url: `${SITE_URL}/guide/getting-started/` },
+  ethos: { name: 'Ethos', url: `${SITE_URL}/ethos/open-source/` },
+  questions: { name: 'Questions', url: `${SITE_URL}/questions/` },
+};
+
+const currentUrl = new URL(Astro.url.pathname, Astro.site).href;
+const breadcrumbs: Breadcrumb[] = [{ name: 'Home', url: `${SITE_URL}/` }];
+if (section && sectionMeta[section]) {
+  breadcrumbs.push(sectionMeta[section]);
+  if (sectionMeta[section].url !== currentUrl) {
+    breadcrumbs.push({ name: title, url: currentUrl });
+  }
+}
+
+const structuredData: Partial<StructuredDataInput> = {
+  type: fm?.pageType ?? 'webpage',
+  title,
+  description,
+  breadcrumbs,
+  ...(fm?.howToSteps ? { howToSteps: fm.howToSteps } : {}),
+  ...Astro.props.structuredData,
+};
 ---
 
-<BaseLayout title={`${title} — walk · talk · meditate`} description={description}>
+<BaseLayout title={`${title} — walk · talk · meditate`} description={description} structuredData={structuredData}>
   <Header />
   <main class="max-w-wide mx-auto px-6 pb-12">
     <div class:list={['flex gap-20', section ? '' : 'justify-center']}>

--- a/src/lib/structured-data.test.ts
+++ b/src/lib/structured-data.test.ts
@@ -8,7 +8,7 @@ import {
   SAME_AS,
   mobileAppNode,
   APP_ID,
-} from './structuredData';
+} from './structured-data';
 
 describe('organizationNode', () => {
   it('is an Organization named Walk Talk Meditate with the shared @id', () => {
@@ -173,6 +173,21 @@ describe('howto graph', () => {
     const types = graph['@graph'].map((n) => n['@type']);
     expect(types).toContain('WebPage');
   });
+
+  it('links the HowTo to the page via @id and mainEntity', () => {
+    const url = 'https://walktalkmeditate.org/guide/getting-started/';
+    const graph = buildGraph({
+      type: 'howto',
+      url,
+      title: 'Getting Started',
+      description: 'Your on-ramp to a pilgrimage.',
+      howToSteps: ['Choose a route'],
+    });
+    const page = graph['@graph'].find((n) => n['@type'] === 'WebPage')!;
+    const howto = graph['@graph'].find((n) => n['@type'] === 'HowTo')!;
+    expect(howto['@id']).toBe(`${url}#howto`);
+    expect(page.mainEntity).toEqual({ '@id': `${url}#howto` });
+  });
 });
 
 describe('questionList graph', () => {
@@ -207,5 +222,20 @@ describe('questionList graph', () => {
       ],
     }) as { '@graph': Array<Record<string, unknown>> };
     expect(graph['@graph'].some((n) => n['@type'] === 'BreadcrumbList')).toBe(true);
+  });
+
+  it('links the ItemList to the page via @id and mainEntity', () => {
+    const url = 'https://walktalkmeditate.org/questions/morning/';
+    const graph = buildGraph({
+      type: 'questionList',
+      url,
+      title: 'Morning Seeds',
+      description: 'Prompts for morning meditation.',
+      items: ['What is alive in you?'],
+    });
+    const page = graph['@graph'].find((n) => n['@type'] === 'CollectionPage')!;
+    const list = graph['@graph'].find((n) => n['@type'] === 'ItemList')!;
+    expect(list['@id']).toBe(`${url}#items`);
+    expect(page.mainEntity).toEqual({ '@id': `${url}#items` });
   });
 });

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -4,13 +4,16 @@ export const WEBSITE_ID = `${SITE_URL}/#website`;
 
 const LOGO_URL = `${SITE_URL}/logo-128.png`;
 const OG_IMAGE = `${SITE_URL}/og.png`;
-const TAGLINE = 'An open-source pilgrimage framework for walking, talking, and meditating.';
+export const TAGLINE = 'An open-source pilgrimage framework for walking, talking, and meditating.';
+
+export const IOS_STORE_URL = 'https://apps.apple.com/app/pilgrim-mindful-walking/id6760921056';
+export const ANDROID_STORE_URL = 'https://play.google.com/store/apps/details?id=org.walktalkmeditate.pilgrim';
+export const APP_STORE_URLS: string[] = [IOS_STORE_URL, ANDROID_STORE_URL];
 
 export const SAME_AS: string[] = [
   'https://pilgrimapp.org',
   'https://github.com/walktalkmeditate',
-  'https://apps.apple.com/app/pilgrim-mindful-walking/id6760921056',
-  'https://play.google.com/store/apps/details?id=org.walktalkmeditate.pilgrim',
+  ...APP_STORE_URLS,
   'https://mastodon.social/@pilgrimage',
   'https://bsky.app/profile/pilgrima.ge',
   'https://www.threads.com/@pilgrima.ge',
@@ -41,7 +44,7 @@ export function organizationNode(): Node {
     '@id': ORG_ID,
     name: 'Walk Talk Meditate',
     url: SITE_URL,
-    logo: LOGO_URL,
+    logo: { '@type': 'ImageObject', url: LOGO_URL },
     description: TAGLINE,
     sameAs: SAME_AS,
   };
@@ -94,11 +97,6 @@ export function breadcrumbNode(url: string, crumbs: Breadcrumb[]): Node {
 
 export const APP_ID = `${SITE_URL}/pilgrim/#app`;
 
-const APP_STORE_URLS: string[] = [
-  'https://apps.apple.com/app/pilgrim-mindful-walking/id6760921056',
-  'https://play.google.com/store/apps/details?id=org.walktalkmeditate.pilgrim',
-];
-
 export function mobileAppNode(): Node {
   return {
     '@type': 'MobileApplication',
@@ -123,6 +121,7 @@ export function mobileAppNode(): Node {
 function howToNode(input: StructuredDataInput): Node {
   return {
     '@type': 'HowTo',
+    '@id': `${input.url}#howto`,
     name: input.title,
     description: input.description,
     step: (input.howToSteps ?? []).map((s, i) => ({
@@ -137,6 +136,7 @@ function itemListNode(input: StructuredDataInput): Node {
   const items = input.items ?? [];
   return {
     '@type': 'ItemList',
+    '@id': `${input.url}#items`,
     name: input.title,
     numberOfItems: items.length,
     itemListElement: items.map((text, i) => ({
@@ -147,7 +147,12 @@ function itemListNode(input: StructuredDataInput): Node {
   };
 }
 
-export function buildGraph(input: StructuredDataInput): Record<string, unknown> {
+export interface SchemaGraph {
+  '@context': string;
+  '@graph': Record<string, unknown>[];
+}
+
+export function buildGraph(input: StructuredDataInput): SchemaGraph {
   const graph: Node[] = [organizationNode(), websiteNode()];
   const crumbs = input.breadcrumbs ?? [];
   const pushBreadcrumb = () => {
@@ -163,11 +168,11 @@ export function buildGraph(input: StructuredDataInput): Record<string, unknown> 
       pushBreadcrumb();
       break;
     case 'howto':
-      graph.push(webPageNode(input, 'WebPage'), howToNode(input));
+      graph.push(webPageNode(input, 'WebPage', `${input.url}#howto`), howToNode(input));
       pushBreadcrumb();
       break;
     case 'questionList':
-      graph.push(webPageNode(input, 'CollectionPage'), itemListNode(input));
+      graph.push(webPageNode(input, 'CollectionPage', `${input.url}#items`), itemListNode(input));
       pushBreadcrumb();
       break;
     case 'collection':

--- a/src/lib/structuredData.test.ts
+++ b/src/lib/structuredData.test.ts
@@ -6,6 +6,8 @@ import {
   ORG_ID,
   WEBSITE_ID,
   SAME_AS,
+  mobileAppNode,
+  APP_ID,
 } from './structuredData';
 import { breadcrumbNode } from './structuredData';
 
@@ -90,5 +92,86 @@ describe('collection graph', () => {
     const types = graph['@graph'].map((n) => n['@type']);
     expect(types).toContain('CollectionPage');
     expect(types).not.toContain('WebPage');
+  });
+});
+
+describe('mobileAppNode', () => {
+  it('is a free MobileApplication published by the org, pointing at pilgrimapp.org', () => {
+    const app = mobileAppNode();
+    expect(app['@type']).toBe('MobileApplication');
+    expect(app['@id']).toBe(APP_ID);
+    expect(app.url).toBe('https://pilgrimapp.org');
+    expect(app.publisher).toEqual({ '@id': ORG_ID });
+    expect(app.offers).toMatchObject({ price: '0', priceCurrency: 'USD' });
+  });
+});
+
+describe('home graph', () => {
+  it('has a WebPage whose mainEntity is the org, plus the Pilgrim app', () => {
+    const graph = buildGraph({
+      type: 'home',
+      url: 'https://walktalkmeditate.org/',
+      title: 'walk · talk · meditate',
+      description: 'An open-source pilgrimage framework.',
+    }) as { '@graph': Array<Record<string, unknown>> };
+    const page = graph['@graph'].find((n) => n['@type'] === 'WebPage')!;
+    expect(page.mainEntity).toEqual({ '@id': ORG_ID });
+    expect(graph['@graph'].some((n) => n['@type'] === 'MobileApplication')).toBe(true);
+  });
+});
+
+describe('app graph', () => {
+  it("has a WebPage whose mainEntity is the app's @id", () => {
+    const graph = buildGraph({
+      type: 'app',
+      url: 'https://walktalkmeditate.org/pilgrim/',
+      title: 'Pilgrim',
+      description: 'The app for the practice.',
+      breadcrumbs: [
+        { name: 'Home', url: 'https://walktalkmeditate.org/' },
+        { name: 'Pilgrim', url: 'https://walktalkmeditate.org/pilgrim/' },
+      ],
+    }) as { '@graph': Array<Record<string, unknown>> };
+    const page = graph['@graph'].find((n) => n['@type'] === 'WebPage')!;
+    expect(page.mainEntity).toEqual({ '@id': APP_ID });
+    expect(graph['@graph'].some((n) => n['@type'] === 'BreadcrumbList')).toBe(true);
+  });
+});
+
+describe('howto graph', () => {
+  it('adds a HowTo with positioned steps', () => {
+    const graph = buildGraph({
+      type: 'howto',
+      url: 'https://walktalkmeditate.org/guide/getting-started/',
+      title: 'Getting Started',
+      description: 'Your on-ramp to a pilgrimage.',
+      howToSteps: ['Choose a route', 'Pick a question', 'Walk'],
+      breadcrumbs: [{ name: 'Home', url: 'https://walktalkmeditate.org/' }],
+    }) as { '@graph': Array<Record<string, unknown>> };
+    const howto = graph['@graph'].find((n) => n['@type'] === 'HowTo')! as {
+      step: Array<{ position: number; text: string }>;
+    };
+    expect(howto.step).toHaveLength(3);
+    expect(howto.step[0]).toMatchObject({ position: 1, text: 'Choose a route' });
+  });
+});
+
+describe('questionList graph', () => {
+  it('adds an ItemList of the question texts on a CollectionPage', () => {
+    const graph = buildGraph({
+      type: 'questionList',
+      url: 'https://walktalkmeditate.org/questions/morning/',
+      title: 'Morning Seeds',
+      description: 'Prompts for morning meditation.',
+      items: ['What is alive in you?', 'What will you let go of?'],
+    }) as { '@graph': Array<Record<string, unknown>> };
+    const types = graph['@graph'].map((n) => n['@type']);
+    expect(types).toContain('CollectionPage');
+    const list = graph['@graph'].find((n) => n['@type'] === 'ItemList')! as {
+      numberOfItems: number;
+      itemListElement: unknown[];
+    };
+    expect(list.numberOfItems).toBe(2);
+    expect(list.itemListElement).toHaveLength(2);
   });
 });

--- a/src/lib/structuredData.test.ts
+++ b/src/lib/structuredData.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import {
+  organizationNode,
+  websiteNode,
+  buildGraph,
+  ORG_ID,
+  WEBSITE_ID,
+  SAME_AS,
+} from './structuredData';
+
+describe('organizationNode', () => {
+  it('is an Organization named Walk Talk Meditate with the shared @id', () => {
+    const node = organizationNode();
+    expect(node['@type']).toBe('Organization');
+    expect(node['@id']).toBe(ORG_ID);
+    expect(node.name).toBe('Walk Talk Meditate');
+  });
+
+  it('includes pilgrimapp.org in sameAs to fuse the ecosystem', () => {
+    expect(SAME_AS).toContain('https://pilgrimapp.org');
+    expect(organizationNode().sameAs).toEqual(SAME_AS);
+  });
+});
+
+describe('websiteNode', () => {
+  it('is a WebSite published by the organization', () => {
+    const node = websiteNode();
+    expect(node['@type']).toBe('WebSite');
+    expect(node['@id']).toBe(WEBSITE_ID);
+    expect(node.publisher).toEqual({ '@id': ORG_ID });
+  });
+});
+
+describe('buildGraph', () => {
+  it('always includes the organization and website nodes', () => {
+    const graph = buildGraph({
+      type: 'webpage',
+      url: 'https://walktalkmeditate.org/walk/',
+      title: 'Walk',
+      description: 'Walking as practice.',
+    }) as { '@context': string; '@graph': Array<Record<string, unknown>> };
+    expect(graph['@context']).toBe('https://schema.org');
+    const types = graph['@graph'].map((n) => n['@type']);
+    expect(types).toContain('Organization');
+    expect(types).toContain('WebSite');
+  });
+});

--- a/src/lib/structuredData.test.ts
+++ b/src/lib/structuredData.test.ts
@@ -7,6 +7,7 @@ import {
   WEBSITE_ID,
   SAME_AS,
 } from './structuredData';
+import { breadcrumbNode } from './structuredData';
 
 describe('organizationNode', () => {
   it('is an Organization named Walk Talk Meditate with the shared @id', () => {
@@ -43,5 +44,51 @@ describe('buildGraph', () => {
     const types = graph['@graph'].map((n) => n['@type']);
     expect(types).toContain('Organization');
     expect(types).toContain('WebSite');
+  });
+});
+
+describe('webpage graph', () => {
+  const input = {
+    type: 'webpage' as const,
+    url: 'https://walktalkmeditate.org/guide/planning/',
+    title: 'Planning',
+    description: 'Logistics for solo and group pilgrimages.',
+    breadcrumbs: [
+      { name: 'Home', url: 'https://walktalkmeditate.org/' },
+      { name: 'Guide', url: 'https://walktalkmeditate.org/guide/getting-started/' },
+      { name: 'Planning', url: 'https://walktalkmeditate.org/guide/planning/' },
+    ],
+  };
+
+  it('adds a WebPage that is part of the website and references its breadcrumb', () => {
+    const graph = buildGraph(input) as { '@graph': Array<Record<string, unknown>> };
+    const page = graph['@graph'].find((n) => n['@type'] === 'WebPage')!;
+    expect(page['@id']).toBe('https://walktalkmeditate.org/guide/planning/#webpage');
+    expect(page.isPartOf).toEqual({ '@id': WEBSITE_ID });
+    expect(page.breadcrumb).toEqual({ '@id': 'https://walktalkmeditate.org/guide/planning/#breadcrumb' });
+  });
+
+  it('adds a BreadcrumbList with positioned items', () => {
+    const graph = buildGraph(input) as { '@graph': Array<Record<string, unknown>> };
+    const crumb = graph['@graph'].find((n) => n['@type'] === 'BreadcrumbList')! as {
+      itemListElement: Array<{ position: number; name: string; item: string }>;
+    };
+    expect(crumb.itemListElement).toHaveLength(3);
+    expect(crumb.itemListElement[0]).toMatchObject({ position: 1, name: 'Home' });
+    expect(crumb.itemListElement[2]).toMatchObject({ position: 3, name: 'Planning' });
+  });
+});
+
+describe('collection graph', () => {
+  it('uses CollectionPage as the page type', () => {
+    const graph = buildGraph({
+      type: 'collection',
+      url: 'https://walktalkmeditate.org/questions/',
+      title: 'Questions',
+      description: 'Curated questions for the journey.',
+    }) as { '@graph': Array<Record<string, unknown>> };
+    const types = graph['@graph'].map((n) => n['@type']);
+    expect(types).toContain('CollectionPage');
+    expect(types).not.toContain('WebPage');
   });
 });

--- a/src/lib/structuredData.test.ts
+++ b/src/lib/structuredData.test.ts
@@ -9,7 +9,6 @@ import {
   mobileAppNode,
   APP_ID,
 } from './structuredData';
-import { breadcrumbNode } from './structuredData';
 
 describe('organizationNode', () => {
   it('is an Organization named Walk Talk Meditate with the shared @id', () => {
@@ -104,6 +103,14 @@ describe('mobileAppNode', () => {
     expect(app.publisher).toEqual({ '@id': ORG_ID });
     expect(app.offers).toMatchObject({ price: '0', priceCurrency: 'USD' });
   });
+
+  it('includes both store URLs in sameAs', () => {
+    const app = mobileAppNode();
+    expect(app.sameAs as string[]).toEqual(expect.arrayContaining([
+      'https://apps.apple.com/app/pilgrim-mindful-walking/id6760921056',
+      'https://play.google.com/store/apps/details?id=org.walktalkmeditate.pilgrim',
+    ]));
+  });
 });
 
 describe('home graph', () => {
@@ -154,6 +161,18 @@ describe('howto graph', () => {
     expect(howto.step).toHaveLength(3);
     expect(howto.step[0]).toMatchObject({ position: 1, text: 'Choose a route' });
   });
+
+  it('includes a WebPage node', () => {
+    const graph = buildGraph({
+      type: 'howto',
+      url: 'https://walktalkmeditate.org/guide/getting-started/',
+      title: 'Getting Started',
+      description: 'Your on-ramp to a pilgrimage.',
+      howToSteps: ['Choose a route'],
+    }) as { '@graph': Array<Record<string, unknown>> };
+    const types = graph['@graph'].map((n) => n['@type']);
+    expect(types).toContain('WebPage');
+  });
 });
 
 describe('questionList graph', () => {
@@ -173,5 +192,20 @@ describe('questionList graph', () => {
     };
     expect(list.numberOfItems).toBe(2);
     expect(list.itemListElement).toHaveLength(2);
+  });
+
+  it('includes a BreadcrumbList node when breadcrumbs are provided', () => {
+    const graph = buildGraph({
+      type: 'questionList',
+      url: 'https://walktalkmeditate.org/questions/morning/',
+      title: 'Morning Seeds',
+      description: 'Prompts for morning meditation.',
+      items: ['What is alive in you?'],
+      breadcrumbs: [
+        { name: 'Home', url: 'https://walktalkmeditate.org/' },
+        { name: 'Questions', url: 'https://walktalkmeditate.org/questions/' },
+      ],
+    }) as { '@graph': Array<Record<string, unknown>> };
+    expect(graph['@graph'].some((n) => n['@type'] === 'BreadcrumbList')).toBe(true);
   });
 });

--- a/src/lib/structuredData.ts
+++ b/src/lib/structuredData.ts
@@ -59,7 +59,7 @@ export function websiteNode(): Node {
   };
 }
 
-function webPageNode(input: StructuredDataInput, schemaType: string, mainEntityId?: string): Node {
+function webPageNode(input: StructuredDataInput, schemaType: 'WebPage' | 'CollectionPage', mainEntityId?: string): Node {
   const node: Node = {
     '@type': schemaType,
     '@id': `${input.url}#webpage`,

--- a/src/lib/structuredData.ts
+++ b/src/lib/structuredData.ts
@@ -59,7 +59,57 @@ export function websiteNode(): Node {
   };
 }
 
+function webPageNode(input: StructuredDataInput, schemaType: string, mainEntityId?: string): Node {
+  const node: Node = {
+    '@type': schemaType,
+    '@id': `${input.url}#webpage`,
+    url: input.url,
+    name: input.title,
+    description: input.description,
+    isPartOf: { '@id': WEBSITE_ID },
+    inLanguage: 'en',
+    primaryImageOfPage: OG_IMAGE,
+  };
+  if (input.breadcrumbs && input.breadcrumbs.length > 0) {
+    node.breadcrumb = { '@id': `${input.url}#breadcrumb` };
+  }
+  if (mainEntityId) {
+    node.mainEntity = { '@id': mainEntityId };
+  }
+  return node;
+}
+
+export function breadcrumbNode(url: string, crumbs: Breadcrumb[]): Node {
+  return {
+    '@type': 'BreadcrumbList',
+    '@id': `${url}#breadcrumb`,
+    itemListElement: crumbs.map((c, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      name: c.name,
+      item: c.url,
+    })),
+  };
+}
+
 export function buildGraph(input: StructuredDataInput): Record<string, unknown> {
   const graph: Node[] = [organizationNode(), websiteNode()];
+  const crumbs = input.breadcrumbs ?? [];
+  const pushBreadcrumb = () => {
+    if (crumbs.length > 0) graph.push(breadcrumbNode(input.url, crumbs));
+  };
+
+  switch (input.type) {
+    case 'collection':
+      graph.push(webPageNode(input, 'CollectionPage'));
+      pushBreadcrumb();
+      break;
+    case 'webpage':
+    default:
+      graph.push(webPageNode(input, 'WebPage'));
+      pushBreadcrumb();
+      break;
+  }
+
   return { '@context': 'https://schema.org', '@graph': graph };
 }

--- a/src/lib/structuredData.ts
+++ b/src/lib/structuredData.ts
@@ -1,0 +1,65 @@
+export const SITE_URL = 'https://walktalkmeditate.org';
+export const ORG_ID = `${SITE_URL}/#organization`;
+export const WEBSITE_ID = `${SITE_URL}/#website`;
+
+const LOGO_URL = `${SITE_URL}/logo-128.png`;
+const OG_IMAGE = `${SITE_URL}/og.png`;
+const TAGLINE = 'An open-source pilgrimage framework for walking, talking, and meditating.';
+
+export const SAME_AS: string[] = [
+  'https://pilgrimapp.org',
+  'https://github.com/walktalkmeditate',
+  'https://apps.apple.com/app/pilgrim-mindful-walking/id6760921056',
+  'https://play.google.com/store/apps/details?id=org.walktalkmeditate.pilgrim',
+  'https://mastodon.social/@pilgrimage',
+  'https://bsky.app/profile/pilgrima.ge',
+  'https://www.threads.com/@pilgrima.ge',
+];
+
+export type PageType = 'home' | 'webpage' | 'collection' | 'howto' | 'questionList' | 'app';
+
+export interface Breadcrumb {
+  name: string;
+  url: string;
+}
+
+export interface StructuredDataInput {
+  type: PageType;
+  url: string;
+  title: string;
+  description: string;
+  breadcrumbs?: Breadcrumb[];
+  items?: string[];
+  howToSteps?: string[];
+}
+
+type Node = Record<string, unknown>;
+
+export function organizationNode(): Node {
+  return {
+    '@type': 'Organization',
+    '@id': ORG_ID,
+    name: 'Walk Talk Meditate',
+    url: SITE_URL,
+    logo: LOGO_URL,
+    description: TAGLINE,
+    sameAs: SAME_AS,
+  };
+}
+
+export function websiteNode(): Node {
+  return {
+    '@type': 'WebSite',
+    '@id': WEBSITE_ID,
+    url: SITE_URL,
+    name: 'walk · talk · meditate',
+    description: TAGLINE,
+    inLanguage: 'en',
+    publisher: { '@id': ORG_ID },
+  };
+}
+
+export function buildGraph(input: StructuredDataInput): Record<string, unknown> {
+  const graph: Node[] = [organizationNode(), websiteNode()];
+  return { '@context': 'https://schema.org', '@graph': graph };
+}

--- a/src/lib/structuredData.ts
+++ b/src/lib/structuredData.ts
@@ -92,6 +92,61 @@ export function breadcrumbNode(url: string, crumbs: Breadcrumb[]): Node {
   };
 }
 
+export const APP_ID = `${SITE_URL}/pilgrim/#app`;
+
+const APP_STORE_URLS: string[] = [
+  'https://apps.apple.com/app/pilgrim-mindful-walking/id6760921056',
+  'https://play.google.com/store/apps/details?id=org.walktalkmeditate.pilgrim',
+];
+
+export function mobileAppNode(): Node {
+  return {
+    '@type': 'MobileApplication',
+    '@id': APP_ID,
+    name: 'Pilgrim',
+    url: 'https://pilgrimapp.org',
+    operatingSystem: 'iOS, Android',
+    applicationCategory: 'HealthApplication',
+    description: 'A privacy-first walking and meditation companion — the app for the walk · talk · meditate practice.',
+    offers: {
+      '@type': 'Offer',
+      price: '0',
+      priceCurrency: 'USD',
+      availability: 'https://schema.org/InStock',
+    },
+    isAccessibleForFree: true,
+    publisher: { '@id': ORG_ID },
+    sameAs: APP_STORE_URLS,
+  };
+}
+
+function howToNode(input: StructuredDataInput): Node {
+  return {
+    '@type': 'HowTo',
+    name: input.title,
+    description: input.description,
+    step: (input.howToSteps ?? []).map((s, i) => ({
+      '@type': 'HowToStep',
+      position: i + 1,
+      text: s,
+    })),
+  };
+}
+
+function itemListNode(input: StructuredDataInput): Node {
+  const items = input.items ?? [];
+  return {
+    '@type': 'ItemList',
+    name: input.title,
+    numberOfItems: items.length,
+    itemListElement: items.map((text, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      name: text,
+    })),
+  };
+}
+
 export function buildGraph(input: StructuredDataInput): Record<string, unknown> {
   const graph: Node[] = [organizationNode(), websiteNode()];
   const crumbs = input.breadcrumbs ?? [];
@@ -100,6 +155,21 @@ export function buildGraph(input: StructuredDataInput): Record<string, unknown> 
   };
 
   switch (input.type) {
+    case 'home':
+      graph.push(webPageNode(input, 'WebPage', ORG_ID), mobileAppNode());
+      break;
+    case 'app':
+      graph.push(webPageNode(input, 'WebPage', APP_ID), mobileAppNode());
+      pushBreadcrumb();
+      break;
+    case 'howto':
+      graph.push(webPageNode(input, 'WebPage'), howToNode(input));
+      pushBreadcrumb();
+      break;
+    case 'questionList':
+      graph.push(webPageNode(input, 'CollectionPage'), itemListNode(input));
+      pushBreadcrumb();
+      break;
     case 'collection':
       graph.push(webPageNode(input, 'CollectionPage'));
       pushBreadcrumb();

--- a/src/pages/guide/getting-started.mdx
+++ b/src/pages/guide/getting-started.mdx
@@ -3,6 +3,13 @@ layout: ../../layouts/ContentLayout.astro
 title: Getting Started
 description: Your on-ramp to a pilgrimage — solo or group, local or abroad.
 section: guide
+pageType: howto
+howToSteps:
+  - Choose a route — 2–3 hours of walking, ideally on paths rather than roads
+  - Pick a question — choose one from the morning seeds to carry with you
+  - Walk — at a comfortable pace, present with each step
+  - Reflect — voice-record or journal after your walk
+  - Sit — close with 10–30 minutes of meditation
 ---
 
 A pilgrimage doesn't require a plane ticket, a group, or weeks of planning. It requires a decision to walk, talk, and meditate with intention.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -89,6 +89,21 @@ const base = import.meta.env.BASE_URL;
         Find fellow pilgrims. Organize a walk. Share your story.
       </p>
     </section>
+
+    <div class="border-t border-sand-200 dark:border-dusk-800" />
+
+    <section class="py-20 md:py-28 reveal">
+      <a
+        href={`${base}pilgrim/`}
+        class="group inline-flex items-center gap-3 font-heading text-2xl md:text-3xl font-light text-sand-800 dark:text-dusk-100 hover:text-sage dark:hover:text-sage-light transition-colors tracking-display"
+      >
+        Carry the practice with Pilgrim
+        <span class="text-sand-300 dark:text-dusk-700 group-hover:text-sage dark:group-hover:text-sage-light group-hover:translate-x-1 transition-all">→</span>
+      </a>
+      <p class="mt-4 text-sand-400 dark:text-dusk-300 font-ui text-sm">
+        The companion app. Privacy-first, open source, free forever.
+      </p>
+    </section>
   </main>
 
   <Footer />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,9 +5,10 @@ import Footer from '../components/Footer.astro';
 import PillarCard from '../components/PillarCard.astro';
 
 const base = import.meta.env.BASE_URL;
+const description = 'An open-source pilgrimage framework for walking, talking, and meditating — solo or group, local or abroad.';
 ---
 
-<BaseLayout title="walk · talk · meditate" structuredData={{ type: 'home', description: 'An open-source pilgrimage framework for walking, talking, and meditating — solo or group, local or abroad.' }}>
+<BaseLayout title="walk · talk · meditate" description={description} structuredData={{ type: 'home', description }}>
   <Header />
 
   <main class="max-w-wide mx-auto px-6">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,7 +7,7 @@ import PillarCard from '../components/PillarCard.astro';
 const base = import.meta.env.BASE_URL;
 ---
 
-<BaseLayout title="walk · talk · meditate">
+<BaseLayout title="walk · talk · meditate" structuredData={{ type: 'home', description: 'An open-source pilgrimage framework for walking, talking, and meditating — solo or group, local or abroad.' }}>
   <Header />
 
   <main class="max-w-wide mx-auto px-6">

--- a/src/pages/pilgrim.astro
+++ b/src/pages/pilgrim.astro
@@ -2,6 +2,7 @@
 import ContentLayout from '../layouts/ContentLayout.astro';
 import { SITE_URL } from '../lib/structuredData';
 
+const base = import.meta.env.BASE_URL;
 const breadcrumbs = [
   { name: 'Home', url: `${SITE_URL}/` },
   { name: 'Pilgrim', url: `${SITE_URL}/pilgrim/` },
@@ -22,13 +23,13 @@ const breadcrumbs = [
   <h2>The three pillars, in your pocket</h2>
   <ul>
     <li><strong>Walk</strong> — GPS route tracking and voice notes transcribed on-device, so a thought mid-walk is never lost.</li>
-    <li><strong>Talk</strong> — reflection prompts generated from your own voice notes and photos, alongside the curated <a href="/questions/">65 questions</a>.</li>
+    <li><strong>Talk</strong> — reflection prompts generated from your own voice notes and photos, alongside the curated <a href={`${base}questions/`}>65 questions</a>.</li>
     <li><strong>Meditate</strong> — a walking-meditation breathing circle with ambient soundscapes and seven voice guides.</li>
   </ul>
 
   <p>
     Everything stays on your phone. Voice transcription runs entirely on-device. The
-    full source is on <a href="https://github.com/walktalkmeditate/pilgrim-ios">GitHub</a>.
+    full source is on <a href="https://github.com/walktalkmeditate">GitHub</a>.
   </p>
 
   <div class="mt-10 flex flex-wrap gap-4 not-prose">

--- a/src/pages/pilgrim.astro
+++ b/src/pages/pilgrim.astro
@@ -1,0 +1,53 @@
+---
+import ContentLayout from '../layouts/ContentLayout.astro';
+import { SITE_URL } from '../lib/structuredData';
+
+const breadcrumbs = [
+  { name: 'Home', url: `${SITE_URL}/` },
+  { name: 'Pilgrim', url: `${SITE_URL}/pilgrim/` },
+];
+---
+
+<ContentLayout
+  title="Pilgrim"
+  description="The companion app for the walk · talk · meditate practice — privacy-first, open source, free forever."
+  structuredData={{ type: 'app', breadcrumbs }}
+>
+  <p>
+    walk · talk · meditate is the practice. <strong>Pilgrim</strong> is the tool you
+    carry on the path — a quiet, privacy-first companion for iPhone and Android. No
+    accounts, no analytics, no cloud. Open source, free forever.
+  </p>
+
+  <h2>The three pillars, in your pocket</h2>
+  <ul>
+    <li><strong>Walk</strong> — GPS route tracking and voice notes transcribed on-device, so a thought mid-walk is never lost.</li>
+    <li><strong>Talk</strong> — reflection prompts generated from your own voice notes and photos, alongside the curated <a href="/questions/">65 questions</a>.</li>
+    <li><strong>Meditate</strong> — a walking-meditation breathing circle with ambient soundscapes and seven voice guides.</li>
+  </ul>
+
+  <p>
+    Everything stays on your phone. Voice transcription runs entirely on-device. The
+    full source is on <a href="https://github.com/walktalkmeditate/pilgrim-ios">GitHub</a>.
+  </p>
+
+  <div class="mt-10 flex flex-wrap gap-4 not-prose">
+    <a
+      href="https://apps.apple.com/app/pilgrim-mindful-walking/id6760921056"
+      class="inline-flex items-center font-ui text-sm px-5 py-3 rounded-lg bg-sand-800 text-sand-50 dark:bg-dusk-100 dark:text-dusk-900 hover:opacity-80 transition-opacity"
+    >
+      Download for iOS
+    </a>
+    <a
+      href="https://play.google.com/store/apps/details?id=org.walktalkmeditate.pilgrim"
+      class="inline-flex items-center font-ui text-sm px-5 py-3 rounded-lg border border-sand-300 text-sand-700 dark:border-dusk-700 dark:text-dusk-200 hover:border-sand-500 transition-colors"
+    >
+      Download for Android
+    </a>
+  </div>
+
+  <p class="mt-8 font-ui text-sm text-sand-400 dark:text-dusk-300 not-prose">
+    Full details and the contemplative-instrument almanac live at
+    <a href="https://pilgrimapp.org" class="underline hover:text-sand-600 dark:hover:text-dusk-200">pilgrimapp.org</a>.
+  </p>
+</ContentLayout>

--- a/src/pages/pilgrim.astro
+++ b/src/pages/pilgrim.astro
@@ -1,6 +1,6 @@
 ---
 import ContentLayout from '../layouts/ContentLayout.astro';
-import { SITE_URL } from '../lib/structuredData';
+import { SITE_URL, IOS_STORE_URL, ANDROID_STORE_URL } from '../lib/structured-data';
 
 const base = import.meta.env.BASE_URL;
 const breadcrumbs = [
@@ -34,13 +34,13 @@ const breadcrumbs = [
 
   <div class="mt-10 flex flex-wrap gap-4 not-prose">
     <a
-      href="https://apps.apple.com/app/pilgrim-mindful-walking/id6760921056"
+      href={IOS_STORE_URL}
       class="inline-flex items-center font-ui text-sm px-5 py-3 rounded-lg bg-sand-800 text-sand-50 dark:bg-dusk-100 dark:text-dusk-900 hover:opacity-80 transition-opacity"
     >
       Download for iOS
     </a>
     <a
-      href="https://play.google.com/store/apps/details?id=org.walktalkmeditate.pilgrim"
+      href={ANDROID_STORE_URL}
       class="inline-flex items-center font-ui text-sm px-5 py-3 rounded-lg border border-sand-300 text-sand-700 dark:border-dusk-700 dark:text-dusk-200 hover:border-sand-500 transition-colors"
     >
       Download for Android

--- a/src/pages/questions/evening.astro
+++ b/src/pages/questions/evening.astro
@@ -7,7 +7,7 @@ const entry = await getEntry('questions', 'evening');
 const { description, questions } = entry!.data;
 ---
 
-<ContentLayout title="Evening Discussion" section="questions" description="Deep questions for Jeffersonian-style group conversation.">
+<ContentLayout title="Evening Discussion" section="questions" description="Deep questions for Jeffersonian-style group conversation." structuredData={{ type: 'questionList', items: questions.map((q) => q.text) }}>
   <p>{description}</p>
 
   <div class="mt-10 not-prose">

--- a/src/pages/questions/index.astro
+++ b/src/pages/questions/index.astro
@@ -4,7 +4,7 @@ import ContentLayout from '../../layouts/ContentLayout.astro';
 const base = import.meta.env.BASE_URL;
 ---
 
-<ContentLayout title="Questions" section="questions" description="Curated questions for walking, talking, and reflecting on pilgrimage.">
+<ContentLayout title="Questions" section="questions" description="Curated questions for walking, talking, and reflecting on pilgrimage." structuredData={{ type: 'collection' }}>
   <p>
     65 questions curated from the original 950 at
     <a href="https://savewisdom.org">savewisdom.org</a>, organized by

--- a/src/pages/questions/morning.astro
+++ b/src/pages/questions/morning.astro
@@ -7,7 +7,7 @@ const entry = await getEntry('questions', 'morning');
 const { description, questions } = entry!.data;
 ---
 
-<ContentLayout title="Morning Seeds" section="questions" description="One-sentence contemplative prompts for morning meditation.">
+<ContentLayout title="Morning Seeds" section="questions" description="One-sentence contemplative prompts for morning meditation." structuredData={{ type: 'questionList', items: questions.map((q) => q.text) }}>
   <p>{description}</p>
 
   <div class="mt-10 not-prose">

--- a/src/pages/questions/solo.astro
+++ b/src/pages/questions/solo.astro
@@ -7,7 +7,7 @@ const entry = await getEntry('questions', 'solo');
 const { description, questions } = entry!.data;
 ---
 
-<ContentLayout title="Solo Reflection" section="questions" description="Introspective prompts for journaling and voice recording.">
+<ContentLayout title="Solo Reflection" section="questions" description="Introspective prompts for journaling and voice recording." structuredData={{ type: 'questionList', items: questions.map((q) => q.text) }}>
   <p>{description}</p>
 
   <div class="mt-10 not-prose">

--- a/src/pages/questions/walking.astro
+++ b/src/pages/questions/walking.astro
@@ -7,7 +7,7 @@ const entry = await getEntry('questions', 'walking');
 const { description, questions } = entry!.data;
 ---
 
-<ContentLayout title="Walking Questions" section="questions" description="Side-by-side conversation prompts for walking.">
+<ContentLayout title="Walking Questions" section="questions" description="Side-by-side conversation prompts for walking." structuredData={{ type: 'questionList', items: questions.map((q) => q.text) }}>
   <p>{description}</p>
 
   <div class="mt-10 not-prose">

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## What

Adds a coherent JSON-LD `@graph` to every page of walktalkmeditate.org, discoverability files, and a Pilgrim companion-app presence — fusing walk·talk·meditate and the Pilgrim app into one ecosystem identity.

Follows the graph + shared-`@id` model from [Hawksley's JSON-LD guide](https://hawksley.dev/blog/json-ld-explained-for-personal-websites/).

## Highlights

- **Structured data** — one `is:inline` JSON-LD block per page (survives view transitions), built by a pure, unit-tested `src/lib/structured-data.ts` module and emitted via `StructuredData.astro` from `BaseLayout`.
  - `Organization` ("Walk Talk Meditate") + `WebSite` on every page; `sameAs` includes `pilgrimapp.org` to unify identity with Pilgrim's own graph.
  - Per-page types: `WebPage`/`CollectionPage`, `BreadcrumbList` (non-home), `HowTo` (getting-started), `ItemList` (question pages), and a `MobileApplication` bridge node for Pilgrim. HowTo/ItemList are linked into the graph via `@id` + `mainEntity`.
- **Discoverability** — `public/llms.txt` (framework overview + companion app) and `public/robots.txt` (→ sitemap).
- **Pilgrim integration** — a slim `/pilgrim/` bridge page (`MobileApplication` JSON-LD), a home-page teaser, and a family footer (Pilgrim · open-pilgrimages · GitHub org). All links one-directional → `pilgrimapp.org`; **no edits to the pilgrim-landing repo**.

## Verification

- `npm test` → 17/17 (Vitest, pure graph module)
- `npx astro check` → 0 errors / 0 warnings / 0 hints
- `npm run build` → 18 pages, sitemap generated
- Emitted graphs validated per page type; home ↔ /pilgrim/ `MobileApplication` share one `@id`.

## Review

Built via spec → plan → subagent-driven implementation (per-task review + whole-branch opus review), then a 9-persona `/ce-code-review` pass. All findings were P2/P3; the actionable set (graph-node linkage, DRY, kebab-case module, ImageObject logo, typed return, pillar breadcrumbs, description sync, llms.txt pillars) is applied in the final commit. Spec + plan included under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)